### PR TITLE
membersテーブルの作成

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -3,4 +3,5 @@ class Member < ApplicationRecord
   belongs_to :trip
 
   enum :host, { member: 0, leader: 1 }
+  validates :host, presence: true
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -1,0 +1,6 @@
+class Member < ApplicationRecord
+  belongs_to :user
+  belongs_to :trip
+
+  enum :host, { member: 0, leader: 1 }
+end

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -1,6 +1,7 @@
 class Trip < ApplicationRecord
   has_many :trip_transportations
   has_many :transportations, through: :trip_transportations, dependent: :destroy
+  has_many :members
   has_one_attached :image
   belongs_to :user
 

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -2,8 +2,8 @@ class Trip < ApplicationRecord
   has_many :trip_transportations
   has_many :transportations, through: :trip_transportations, dependent: :destroy
   has_many :members
+  has_many :trips, through: :members, dependent: :destroy
   has_one_attached :image
-  belongs_to :user
 
   enum :status, { in_progress: 0, completed: 1 }
   validates :title, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
 
   has_many :trips
   has_many :members
+  has_many :users, through: :members, dependent: :destroy
   has_one_attached :avatar
 
   validates :name, presence: :true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_many :trips
+  has_many :members
   has_one_attached :avatar
 
   validates :name, presence: :true

--- a/db/migrate/20250421042801_create_members.rb
+++ b/db/migrate/20250421042801_create_members.rb
@@ -1,0 +1,10 @@
+class CreateMembers < ActiveRecord::Migration[8.0]
+  def change
+    create_table :members do |t|
+      t.integer :host
+      t.references :user, null: false, foreign_key: { on_update: :cascade, on_delete: :cascade }
+      t.references :trip, null: false, foreign_key: { on_update: :cascade, on_delete: :cascade }
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_19_034233) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_21_042801) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -37,6 +37,16 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_19_034233) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "members", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "host"
+    t.bigint "user_id", null: false
+    t.bigint "trip_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["trip_id"], name: "index_members_on_trip_id"
+    t.index ["user_id"], name: "index_members_on_user_id"
   end
 
   create_table "transportations", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -84,6 +94,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_19_034233) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "members", "trips", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "members", "users", on_update: :cascade, on_delete: :cascade
   add_foreign_key "trip_transportations", "transportations", on_update: :cascade, on_delete: :cascade
   add_foreign_key "trip_transportations", "trips", on_update: :cascade, on_delete: :cascade
   add_foreign_key "trips", "users", on_update: :cascade, on_delete: :cascade

--- a/test/fixtures/trip_transportations.yml
+++ b/test/fixtures/trip_transportations.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/trip_transportation_test.rb
+++ b/test/models/trip_transportation_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TripTransportationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### 概要
しおりごとに参加メンバーおよびリーダーの情報を管理するため、members テーブルを作成しました。
また、各メンバーが「一般メンバー」か「リーダー」かを区別するために enum を導入しています。

---
### 修正内容
1. **membersテーブルの作成**
  - 'user_id' 'trip_id', 'host' カラムを持つusersテーブルとtripsテーブルの中間テーブル
  - tripsとusersの多対多の関係を管理

2. **enumを用いたロールの管理**
  - hostカラムに対して以下の記述を実装
```
  enum :host, { member: 0, leader: 1 }
```
  - これによりリーダーと一般メンバーを区別化
