### PR TITLE
しおり作成後のリダイレクト先を詳細ページに変更

### DIFF
--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -14,7 +14,7 @@ class TripsController < ApplicationController
       )
 
       flash[:notice] = "しおりを作成しました"
-      redirect_to
+      redirect_to trip_path(@trip)
     else
       flash.now[:alert] = @trip.errors.full_messages
       render :new, status: :unprocessable_entity


### PR DESCRIPTION
### 概要
'trips/new'において、しおり作成後のリダイレクト先を'trip_path(trip)'に変更しました
これによりしおり作成後はそのまま詳細ページ(trips#show)に遷移することができます
