### PR TITLE
Tripsテーブルにcreator_idカラムを追加

### DIFF
--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -26,6 +26,6 @@ class TripsController < ApplicationController
   private
 
   def trips_params
-    params.require(:trip).permit(:title, :date, :distination, :spot_suggestion_limit, :spot_vote_limit, :start_time, :finish_time, :image)
+    params.require(:trip).permit(:title, :date, :distination, :spot_suggestion_limit, :spot_vote_limit, :start_time, :finish_time, :image, :creator_id)
   end
 end

--- a/app/views/trips/new.html.erb
+++ b/app/views/trips/new.html.erb
@@ -78,6 +78,7 @@
       <p id="preview"></p>
     </div>
     <div class="submit">
+      <%= f.hidden_field :creator_id, value: current_user.id %>
       <%= f.submit t('.submit'), class:"submit-botton" %>
     </div>
     <% end %>

--- a/db/migrate/20250503030726_add_creator_id_to_trips.rb
+++ b/db/migrate/20250503030726_add_creator_id_to_trips.rb
@@ -1,0 +1,6 @@
+class AddCreatorIdToTrips < ActiveRecord::Migration[8.0]
+  def change
+    add_column :trips, :creator_id, :bigint, null: false
+    add_foreign_key :trips, :users, column: :creator_id, on_update: :cascade, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_22_041728) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_03_030726) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -113,6 +113,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_22_041728) do
     t.integer "status", default: 0, null: false
     t.date "spot_suggestion_limit", null: false
     t.date "spot_vote_limit", null: false
+    t.bigint "creator_id", null: false
+    t.index ["creator_id"], name: "fk_rails_709004fcc4"
   end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -140,4 +142,5 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_22_041728) do
   add_foreign_key "trip_transportations", "trips", on_update: :cascade, on_delete: :cascade
   add_foreign_key "trip_users", "trips", on_update: :cascade, on_delete: :cascade
   add_foreign_key "trip_users", "users", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "trips", "users", column: "creator_id", on_update: :cascade, on_delete: :cascade
 end


### PR DESCRIPTION
### 概要
Tripsテーブルにcreator_idカラムを追加しました
これによりしおりの作成者を簡単に管理することができます

### 修正内容
1. 'creator_id'カラムの作成
  - 'Users'テーブルの外部キーとして'Trips'テーブルに'creator_id'カラムを作成

2. 'Trips/new.html.erb' のフォームにcurrent_user.idを追加
  - hidden_fieldを用いてcurrent_user.idをコントローラへ送信できるように修正(パラメータ名はcreator_id)

3. 'Trips'コントローラの'trip_params'に'creator_id'を追加
