### PR TITLE
画像プレビュー表示のjsを修正

### DIFF
--- a/app/javascript/preview_image.js
+++ b/app/javascript/preview_image.js
@@ -2,7 +2,10 @@
 function loadImage(obj) {
   const allPreview = document.getElementById('post_avatar');
   const newPreview = document.createElement("p");
-  allPreview.querySelector("p").remove();
+  const oldPreview = allPreview.querySelector("p");
+  if (oldPreview) {
+    oldPreview.remove();
+  }
   newPreview.setAttribute("id","preview");
   allPreview.insertBefore(newPreview, allPreview.firstChild);
   const fileReader = new FileReader();

--- a/app/views/trips/new.html.erb
+++ b/app/views/trips/new.html.erb
@@ -75,7 +75,6 @@
       <%= f.file_field :image, class:"text-field", onchange: "loadImage(this);" %>
     </div>
     <div id="post_avatar">
-      <p id="preview"></p>
     </div>
     <div class="submit">
       <%= f.hidden_field :creator_id, value: current_user.id %>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -31,7 +31,6 @@
         <%= f.file_field :avatar, class:"text-field", onchange: "loadImage(this);" %>
       </div>
       <div id="post_avatar">
-        <p id="preview"></p>
       </div>
       <div class="submit-mypage">
         <div class="submit">


### PR DESCRIPTION
### 概要
画像プレビュー表示機能において、以下の変更を行いました
これにより画像のプレビューを安全に表示することができます
- viewの余分な< p >の削除
- < p >が存在しない場合にエラーが起きるのを防ぐために jsに以下の条件分岐を作成
```
  const oldPreview = allPreview.querySelector("p");
  if (oldPreview) {
    oldPreview.remove();
  }
```

### 修正内容
1. ビューから'< p id="preview">< /p >'を削除
  - JSファイルで< p >を付与しているため、この記述は不要

2. 条件分岐を用いて'allPreview'に< p >が存在する場合のみ< p >の削除を実行
  - エラー回避のため
