### PR TITLE
テーブル構造の修正

### DIFF
--- a/app/models/keyword.rb
+++ b/app/models/keyword.rb
@@ -1,0 +1,4 @@
+class Keyword < ApplicationRecord
+  has_many :keyword_spots
+  has_many :spots, through: :keyword_spots, dependent: :destroy
+end

--- a/app/models/keyword_spot.rb
+++ b/app/models/keyword_spot.rb
@@ -1,0 +1,4 @@
+class KeywordSpot < ApplicationRecord
+  belongs_to :keyword
+  belogns_to :spot
+end

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -1,3 +1,5 @@
 class Spot < ApplicationRecord
   has_many :spot_suggestions
+  has_many :keyword_spots
+  has_many :keywords, through: :keyword_spots, dependent: :destroy
 end

--- a/db/migrate/20250421042801_create_trip_users.rb
+++ b/db/migrate/20250421042801_create_trip_users.rb
@@ -2,7 +2,7 @@ class CreateTripUsers < ActiveRecord::Migration[8.0]
   def change
     create_table :trip_users do |t|
       t.integer :host
-      t.references :user, null: false, foreign_key: { on_update: :cascade, on_delete: :cascade }
+      t.references :user, null: false, foreign_key: { on_update: :cascade }
       t.references :trip, null: false, foreign_key: { on_update: :cascade, on_delete: :cascade }
       t.timestamps
     end

--- a/db/migrate/20250422033705_create_spots.rb
+++ b/db/migrate/20250422033705_create_spots.rb
@@ -2,6 +2,7 @@ class CreateSpots < ActiveRecord::Migration[8.0]
   def change
     create_table :spots do |t|
       t.string :spot_name
+      t.integer :unique_number
       t.integer :phone_number
       t.string :opening_hours
       t.string :closing_day

--- a/db/migrate/20250503030726_add_creator_id_to_trips.rb
+++ b/db/migrate/20250503030726_add_creator_id_to_trips.rb
@@ -1,6 +1,6 @@
 class AddCreatorIdToTrips < ActiveRecord::Migration[8.0]
   def change
-    add_column :trips, :creator_id, :bigint, null: false
-    add_foreign_key :trips, :users, column: :creator_id, on_update: :cascade, on_delete: :cascade
+    add_column :trips, :created_user_id, :bigint, null: false
+    add_foreign_key :trips, :users, column: :created_user_id, on_update: :cascade, on_delete: :cascade
   end
 end

--- a/db/migrate/20250506020337_create_keywords.rb
+++ b/db/migrate/20250506020337_create_keywords.rb
@@ -1,0 +1,8 @@
+class CreateKeywords < ActiveRecord::Migration[8.0]
+  def change
+    create_table :keywords do |t|
+      t.string :word, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250506020453_create_keyword_spots.rb
+++ b/db/migrate/20250506020453_create_keyword_spots.rb
@@ -1,0 +1,9 @@
+class CreateKeywordSpots < ActiveRecord::Migration[8.0]
+  def change
+    create_table :keyword_spots do |t|
+      t.references :spot, null: false, foreign_key: { on_update: :cascade, on_delete: :cascade }
+      t.references :keyword, null: false, foreign_key: { on_update: :cascade, on_delete: :cascade }
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_03_030726) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_06_020453) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -39,6 +39,21 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_03_030726) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "keyword_spots", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "spot_id", null: false
+    t.bigint "keyword_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["keyword_id"], name: "index_keyword_spots_on_keyword_id"
+    t.index ["spot_id"], name: "index_keyword_spots_on_spot_id"
+  end
+
+  create_table "keywords", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "word", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "spot_suggestions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.datetime "deadline"
     t.bigint "trip_id", null: false
@@ -65,6 +80,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_03_030726) do
 
   create_table "spots", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "spot_name"
+    t.integer "unique_number"
     t.integer "phone_number"
     t.string "opening_hours"
     t.string "closing_day"
@@ -113,8 +129,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_03_030726) do
     t.integer "status", default: 0, null: false
     t.date "spot_suggestion_limit", null: false
     t.date "spot_vote_limit", null: false
-    t.bigint "creator_id", null: false
-    t.index ["creator_id"], name: "fk_rails_709004fcc4"
+    t.bigint "created_user_id", null: false
+    t.index ["created_user_id"], name: "fk_rails_2542cd4bd9"
   end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -132,6 +148,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_03_030726) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "keyword_spots", "keywords", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "keyword_spots", "spots", on_update: :cascade, on_delete: :cascade
   add_foreign_key "spot_suggestions", "spots", on_update: :cascade, on_delete: :cascade
   add_foreign_key "spot_suggestions", "trips", on_update: :cascade, on_delete: :cascade
   add_foreign_key "spot_suggestions", "users", on_update: :cascade, on_delete: :cascade
@@ -141,6 +159,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_03_030726) do
   add_foreign_key "trip_transportations", "transportations", on_update: :cascade, on_delete: :cascade
   add_foreign_key "trip_transportations", "trips", on_update: :cascade, on_delete: :cascade
   add_foreign_key "trip_users", "trips", on_update: :cascade, on_delete: :cascade
-  add_foreign_key "trip_users", "users", on_update: :cascade, on_delete: :cascade
-  add_foreign_key "trips", "users", column: "creator_id", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "trip_users", "users", on_update: :cascade
+  add_foreign_key "trips", "users", column: "created_user_id", on_update: :cascade, on_delete: :cascade
 end


### PR DESCRIPTION
### 概要
spotsテーブルと多対多のリレーションを持つkeywordsテーブルとその中間テーブルkeyword_spotsテーブルを作成しました
これにより同じキーワードが入力された場合はAPIを叩くのではなくDBから検索することが可能になります。

tripsテーブルのcreator_idカラムの名前をcreated_user_idに変更しました
