### PR TITLE
スポット詳細ページに必要なコントローラの作成

### DIFF
--- a/app/controllers/spot_suggestions_controller.rb
+++ b/app/controllers/spot_suggestions_controller.rb
@@ -1,0 +1,20 @@
+class SpotSuggestionsController < ApplicationController
+  def create
+    spot_suggestion = SpotSuggestion.new(spot_suggestions_params)
+    trip = Trip.find(params[:trip_id])
+    spot = Spot.find(params[:spot_id])
+    if spot_suggestion.save
+      flash[:notice] = "スポットの提案に成功しました"
+      redirect_to trip_path(trip)
+    else
+      flash.now[:alert] = "スポットの提案に失敗しました"
+      redirect_to spot_path(spot)
+    end
+  end
+
+  private
+
+  def spot_suggestions_params
+    params.permit(:user_id, :trip_id, :spot_id)
+  end
+end

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -44,4 +44,7 @@ class SpotsController < ApplicationController
       @first_page = @current_page > 1 ? Spot::MIN_PAGE : nil
       @last_page = @current_page * Spot::PER_PAGE < total_spots ? @total_page : nil
   end
+  def show
+    @spot = Spot.find(params[:id])
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
     registrations: "users/registrations"
   }
   get "/homes", to: "homes#index"
-  get "/spots", to: "spots#index"
+  resources :spots
   resources :trips
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 


### PR DESCRIPTION
### 概要
以下の2つの機能を実装しました。

1. 'SpotsController#show' の作成  
　→ スポットの詳細情報を表示できるようになりました。

2. 'SpotSuggestionsController#create' の作成  
　→ スポット詳細ページから、提案スポットを 'spot_suggestions' テーブルに作成できるようになりました。
