### PR TITLE
turbo-frameを用いた提案フェーズと投票フェーズの表示処理を実装

### DIFF
--- a/app/assets/stylesheets/trips/show.scss
+++ b/app/assets/stylesheets/trips/show.scss
@@ -40,10 +40,22 @@
       width: 400px;
       margin: auto;
       margin-top: 70px;
-    }
-    .label {
-      border: 1px solid black;
-      width: 200px;
+      .suggestion-vote-link {
+        border: 1px solid black;
+        width: 200px;
+      }
+      .suggestion-vote-hilight-link {
+        background-color: #99FFFF;
+        border: 1px solid black;
+        width: 200px;
+      }
+      .suggestion-vote-link a,
+      .suggestion-vote-hilight-link a {
+        font-size: 20px;
+        font-weight: bold;
+        color: inherit;
+        text-decoration: none;
+      }
     }
     .suggestion-vote-container {
       display: flex;
@@ -53,13 +65,13 @@
       .suggestion-vote-card-style {
         width: 400px;
         border: 1px solid black;
-        .suggestion-limit {
+        .suggestion-vote-limit {
           margin-top: 30px;
           color: red;
           text-align: center;
           font-size: 25px;
         }
-        .spot-suggestions-headline {
+        .spot-suggestion-vote-headline {
           margin-top: 30px;
           margin-bottom: 30px;
           text-align: center;
@@ -88,7 +100,7 @@
           }
         }
       }
-      .no-spot-suggestions-headline {
+      .no-spot-suggestion-vote-headline {
         margin-top: 100px;
         margin-bottom: 100px;
         text-align: center;

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -22,6 +22,19 @@ class TripsController < ApplicationController
     @spot_suggestion_by_user = SpotSuggestion.where(trip_id: @trip.id).index_by(&:spot_id)
   end
 
+  def suggestion
+    @trip = Trip.find(params[:id])
+    @spot_suggestions = @trip.spots
+    @spot_suggestion_by_user = SpotSuggestion.where(trip_id: @trip.id).index_by(&:spot_id)
+    render partial: "trips/suggestion"
+  end
+
+  def vote
+    @trip = Trip.find(params[:id])
+    @spot_votes = @trip.spots
+    render partial: "trips/vote"
+  end
+
   private
 
   def trips_params

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -26,13 +26,13 @@ class TripsController < ApplicationController
     @trip = Trip.find(params[:id])
     @spot_suggestions = @trip.spots
     @spot_suggestion_by_user = SpotSuggestion.where(trip_id: @trip.id).index_by(&:spot_id)
-    render partial: "trips/suggestion"
+    render partial: "trips/suggestion", locals: { trip: @trip, spot_suggestions: @spot_suggestions, spot_suggestion_by_user: @spot_suggestion_by_user }
   end
 
   def vote
     @trip = Trip.find(params[:id])
     @spot_votes = @trip.spots
-    render partial: "trips/vote"
+    render partial: "trips/vote", locals: { trip: @trip, spot_votes: @spot_votes }
   end
 
   private

--- a/app/views/trips/_spot.html.erb
+++ b/app/views/trips/_spot.html.erb
@@ -1,0 +1,10 @@
+<div class="spot-image">
+  <%= link_to spot.spot_name.truncate(8), trip_spot_path(spot) %><br>
+  <%= image_tag spot.image_url, class:"image" %>
+  <% if local_assigns[:spot_suggestion_by_user] && spot_suggestion_by_user[spot.id].user_id == current_user.id %>
+    <%= link_to trip_spot_suggestion_path(trip_id: params[:id], spot_id: spot.id), method: :delete, data: { confirm: "本当に削除しますか？" }, class:"spot-delete-link" do %>
+      <i class="fa-solid fa-xmark"></i>
+      <%= t('trips.show.spot_delete')%>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/trips/_suggestion.html.erb
+++ b/app/views/trips/_suggestion.html.erb
@@ -1,0 +1,50 @@
+<turbo-frame id="phase">
+  <div class="label-container">
+    <div class="suggestion-vote-hilight-link">
+      <%= link_to t('trips.show.suggestion-phase'), suggestion_trip_path(@trip), data: { turbo_frame: "phase"} %>
+    </div>
+    <div class="suggestion-vote-link">
+      <%= link_to t('trips.show.vote-phase'), vote_trip_path(@trip), data: { turbo_frame: "phase"} %>
+    </div>
+  </div>
+  <div class="suggestion-vote-container">
+    <div class="suggestion-vote-card-style">
+        <div class="suggestion-vote-limit">
+          <%= t('trips.show.suggestion-limit') %><%= (@trip.spot_suggestion_limit - Date.today).to_i %>日
+        </div>
+        <% if @spot_suggestions.present? %>
+          <div class="spot-suggestion-vote-headline">
+            <%= t("trips.show.spot-suggestions") %>
+          </div>
+          <div class="spot-image-container">
+            <% @spot_suggestions.each do |spot| %>
+              <div class="spot-image">
+                <%= link_to spot.spot_name.truncate(8), trip_spot_path(spot) %><br>
+                <%= image_tag spot.image_url, class:"image" %>
+                  <% if @spot_suggestion_by_user[spot.id].user_id == current_user.id %>
+                    <%= link_to trip_spot_suggestion_path(trip_id: params[:id], spot_id: spot.id), method: :delete, data: { confirm: "本当に削除しますか？" }, class:"spot-delete-link" do %>
+                      <i class="fa-solid fa-xmark"></i>
+                      <%= t('trips.show.spot_delete')%>
+                    <% end %>
+                  <% end %>
+              </div>
+            <% end %>
+          </div>
+        <% else %>
+          <div class="no-spot-suggestion-vote-headline">
+            <%= t('trips.show.no-spot-suggestions') %>
+          </div>
+        <% end %>
+        <%= link_to trip_spots_path(@trip) do %>
+          <div class="spot-add-container">
+            <div class="spot-add">
+              <%= t('trips.show.spot-add')%>
+            </div>
+            <div class="spot-add">
+              <i class="fa-solid fa-circle-plus"></i>
+            </div>
+          </div>
+        <% end %>
+    </div>
+  </div>
+</turbo-frame>  

--- a/app/views/trips/_suggestion.html.erb
+++ b/app/views/trips/_suggestion.html.erb
@@ -1,41 +1,30 @@
 <turbo-frame id="phase">
   <div class="label-container">
     <div class="suggestion-vote-hilight-link">
-      <%= link_to t('trips.show.suggestion-phase'), suggestion_trip_path(@trip), data: { turbo_frame: "phase"} %>
+      <%= link_to t('trips.show.suggestion-phase'), suggestion_trip_path(trip), data: { turbo_frame: "phase"} %>
     </div>
     <div class="suggestion-vote-link">
-      <%= link_to t('trips.show.vote-phase'), vote_trip_path(@trip), data: { turbo_frame: "phase"} %>
+      <%= link_to t('trips.show.vote-phase'), vote_trip_path(trip), data: { turbo_frame: "phase"} %>
     </div>
   </div>
   <div class="suggestion-vote-container">
     <div class="suggestion-vote-card-style">
         <div class="suggestion-vote-limit">
-          <%= t('trips.show.suggestion-limit') %><%= (@trip.spot_suggestion_limit - Date.today).to_i %>日
+          <%= t('trips.show.suggestion-limit') %><%= (trip.spot_suggestion_limit - Date.today).to_i %>日
         </div>
-        <% if @spot_suggestions.present? %>
+        <% if spot_suggestions.present? %>
           <div class="spot-suggestion-vote-headline">
             <%= t("trips.show.spot-suggestions") %>
           </div>
           <div class="spot-image-container">
-            <% @spot_suggestions.each do |spot| %>
-              <div class="spot-image">
-                <%= link_to spot.spot_name.truncate(8), trip_spot_path(spot) %><br>
-                <%= image_tag spot.image_url, class:"image" %>
-                  <% if @spot_suggestion_by_user[spot.id].user_id == current_user.id %>
-                    <%= link_to trip_spot_suggestion_path(trip_id: params[:id], spot_id: spot.id), method: :delete, data: { confirm: "本当に削除しますか？" }, class:"spot-delete-link" do %>
-                      <i class="fa-solid fa-xmark"></i>
-                      <%= t('trips.show.spot_delete')%>
-                    <% end %>
-                  <% end %>
-              </div>
-            <% end %>
+            <%= render partial: "spot", collection: spot_suggestions, :as => "spot", locals: { spot_suggestion_by_user: spot_suggestion_by_user } %>
           </div>
         <% else %>
           <div class="no-spot-suggestion-vote-headline">
             <%= t('trips.show.no-spot-suggestions') %>
           </div>
         <% end %>
-        <%= link_to trip_spots_path(@trip) do %>
+        <%= link_to trip_spots_path(trip) do %>
           <div class="spot-add-container">
             <div class="spot-add">
               <%= t('trips.show.spot-add')%>
@@ -47,4 +36,4 @@
         <% end %>
     </div>
   </div>
-</turbo-frame>  
+</turbo-frame>

--- a/app/views/trips/_vote.html.erb
+++ b/app/views/trips/_vote.html.erb
@@ -1,0 +1,31 @@
+<turbo-frame id="phase">
+  <div class="label-container">
+    <div class="suggestion-vote-link">
+      <%= link_to t('trips.show.suggestion-phase'), suggestion_trip_path(@trip), data: { turbo_frame: "phase"} %>
+    </div>
+    <div class="suggestion-vote-hilight-link">
+      <%= link_to t('trips.show.vote-phase'), vote_trip_path(@trip), data: { turbo_frame: "phase"} %>
+    </div>
+  </div>
+  <div class="suggestion-vote-container">
+    <div class="suggestion-vote-card-style">
+      <div class="suggestion-vote-limit">
+        <%= t('trips.show.vote-limit') %><%= (@trip.spot_vote_limit - Date.today).to_i  %>日
+      </div>
+      <% if @spot_votes.present? %>
+        <div class="spot-image-container">
+          <% @spot_votes.each do |spot| %>
+            <div class="spot-image">
+              <%= link_to spot.spot_name.truncate(8), trip_spot_path(spot) %><br>
+              <%= image_tag spot.image_url, class:"image" %>
+            </div>
+          <% end %>
+        </div>
+      <% else %>
+        <div class="no-spot-suggestion-vote-headline">
+          <%= t('trips.show.no-spot-suggestions') %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</turbo-frame>

--- a/app/views/trips/_vote.html.erb
+++ b/app/views/trips/_vote.html.erb
@@ -1,25 +1,20 @@
 <turbo-frame id="phase">
   <div class="label-container">
     <div class="suggestion-vote-link">
-      <%= link_to t('trips.show.suggestion-phase'), suggestion_trip_path(@trip), data: { turbo_frame: "phase"} %>
+      <%= link_to t('trips.show.suggestion-phase'), suggestion_trip_path(trip), data: { turbo_frame: "phase"} %>
     </div>
     <div class="suggestion-vote-hilight-link">
-      <%= link_to t('trips.show.vote-phase'), vote_trip_path(@trip), data: { turbo_frame: "phase"} %>
+      <%= link_to t('trips.show.vote-phase'), vote_trip_path(trip), data: { turbo_frame: "phase"} %>
     </div>
   </div>
   <div class="suggestion-vote-container">
     <div class="suggestion-vote-card-style">
       <div class="suggestion-vote-limit">
-        <%= t('trips.show.vote-limit') %><%= (@trip.spot_vote_limit - Date.today).to_i  %>日
+        <%= t('trips.show.vote-limit') %><%= (trip.spot_vote_limit - Date.today).to_i  %>日
       </div>
-      <% if @spot_votes.present? %>
+      <% if spot_votes.present? %>
         <div class="spot-image-container">
-          <% @spot_votes.each do |spot| %>
-            <div class="spot-image">
-              <%= link_to spot.spot_name.truncate(8), trip_spot_path(spot) %><br>
-              <%= image_tag spot.image_url, class:"image" %>
-            </div>
-          <% end %>
+          <%= render partial: "spot", collection: spot_votes, :as => "spot" %>
         </div>
       <% else %>
         <div class="no-spot-suggestion-vote-headline">

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -23,54 +23,56 @@
         <%= @trip.distination %>
       </div>
     </div>
-    <div class="label-container">
-      <div class="label">
-        <%= t('.suggestion-phase')%>
-      </div>
-      <div class="label">
-        <%= t('.vote-phase')%>
-      </div>
-    </div>
-    <div class="suggestion-vote-container">
-      <div class="suggestion-vote-card-style">
-        <div class="suggestion-limit">
-          <%= t('.suggestion-limit') %><%= (@trip.spot_suggestion_limit - Date.today).to_i %>日
+    <turbo-frame id="phase">
+      <div class="label-container">
+        <div class="suggestion-vote-hilight-link">
+          <%= link_to t('.suggestion-phase'), suggestion_trip_path(@trip), data: { turbo_frame: "phase"} %>
         </div>
-        <% if @spot_suggestions.present? %>
-          <div class="spot-suggestions-headline">
-            <%= t(".spot-suggestions") %>
-          </div>
-          <div class="spot-image-container">
-            <% @spot_suggestions.each do |spot| %>
-              <div class="spot-image">
-                <%= link_to spot.spot_name.truncate(8), trip_spot_path(spot) %><br>
-                <%= image_tag spot.image_url, class:"image" %>
-                  <% if @spot_suggestion_by_user[spot.id].user_id == current_user.id %>
-                    <%= link_to trip_spot_suggestion_path(trip_id: params[:id], spot_id: spot.id), method: :delete, data: { confirm: "本当に削除しますか？" }, class:"spot-delete-link" do %>
-                      <i class="fa-solid fa-xmark"></i>
-                      <%= t('.spot_delete')%>
-                    <% end %>
-                  <% end %>
+        <div class="suggestion-vote-link">
+          <%= link_to t('.vote-phase'), vote_trip_path(@trip), data: { turbo_frame: "phase"} %>
+        </div>
+      </div>
+      <div class="suggestion-vote-container">
+        <div class="suggestion-vote-card-style">
+            <div class="suggestion-vote-limit">
+              <%= t('.suggestion-limit') %><%= (@trip.spot_suggestion_limit - Date.today).to_i %>日
+            </div>
+            <% if @spot_suggestions.present? %>
+              <div class="spot-suggestion-vote-headline">
+                <%= t(".spot-suggestions") %>
+              </div>
+              <div class="spot-image-container">
+                <% @spot_suggestions.each do |spot| %>
+                  <div class="spot-image">
+                    <%= link_to spot.spot_name.truncate(8), trip_spot_path(spot) %><br>
+                    <%= image_tag spot.image_url, class:"image" %>
+                      <% if @spot_suggestion_by_user[spot.id].user_id == current_user.id %>
+                        <%= link_to trip_spot_suggestion_path(trip_id: params[:id], spot_id: spot.id), method: :delete, data: { confirm: "本当に削除しますか？" }, class:"spot-delete-link" do %>
+                          <i class="fa-solid fa-xmark"></i>
+                          <%= t('.spot_delete')%>
+                        <% end %>
+                      <% end %>
+                  </div>
+                <% end %>
+              </div>
+            <% else %>
+              <div class="no-spot-suggestion-vote-headline">
+                <%= t('.no-spot-suggestions') %>
               </div>
             <% end %>
-          </div>
-        <% else %>
-          <div class="no-spot-suggestions-headline">
-            <%= t('.no-spot-suggestions') %>
-          </div>
-        <% end %>
-        <%= link_to trip_spots_path(@trip) do %>
-          <div class="spot-add-container">
-            <div class="spot-add">
-              <%= t('.spot-add')%>
-            </div>
-            <div class="spot-add">
-              <i class="fa-solid fa-circle-plus"></i>
-            </div>
-          </div>
-        <% end %>
+            <%= link_to trip_spots_path(@trip) do %>
+              <div class="spot-add-container">
+                <div class="spot-add">
+                  <%= t('.spot-add')%>
+                </div>
+                <div class="spot-add">
+                  <i class="fa-solid fa-circle-plus"></i>
+                </div>
+              </div>
+            <% end %>
+        </div>
       </div>
-    </div>
+    </turbo-frame>  
     <div class="member-container">
       <div class="member-card-style">
         <div class="member-title">

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -24,54 +24,7 @@
       </div>
     </div>
     <turbo-frame id="phase">
-      <div class="label-container">
-        <div class="suggestion-vote-hilight-link">
-          <%= link_to t('.suggestion-phase'), suggestion_trip_path(@trip), data: { turbo_frame: "phase"} %>
-        </div>
-        <div class="suggestion-vote-link">
-          <%= link_to t('.vote-phase'), vote_trip_path(@trip), data: { turbo_frame: "phase"} %>
-        </div>
-      </div>
-      <div class="suggestion-vote-container">
-        <div class="suggestion-vote-card-style">
-            <div class="suggestion-vote-limit">
-              <%= t('.suggestion-limit') %><%= (@trip.spot_suggestion_limit - Date.today).to_i %>日
-            </div>
-            <% if @spot_suggestions.present? %>
-              <div class="spot-suggestion-vote-headline">
-                <%= t(".spot-suggestions") %>
-              </div>
-              <div class="spot-image-container">
-                <% @spot_suggestions.each do |spot| %>
-                  <div class="spot-image">
-                    <%= link_to spot.spot_name.truncate(8), trip_spot_path(spot) %><br>
-                    <%= image_tag spot.image_url, class:"image" %>
-                      <% if @spot_suggestion_by_user[spot.id].user_id == current_user.id %>
-                        <%= link_to trip_spot_suggestion_path(trip_id: params[:id], spot_id: spot.id), method: :delete, data: { confirm: "本当に削除しますか？" }, class:"spot-delete-link" do %>
-                          <i class="fa-solid fa-xmark"></i>
-                          <%= t('.spot_delete')%>
-                        <% end %>
-                      <% end %>
-                  </div>
-                <% end %>
-              </div>
-            <% else %>
-              <div class="no-spot-suggestion-vote-headline">
-                <%= t('.no-spot-suggestions') %>
-              </div>
-            <% end %>
-            <%= link_to trip_spots_path(@trip) do %>
-              <div class="spot-add-container">
-                <div class="spot-add">
-                  <%= t('.spot-add')%>
-                </div>
-                <div class="spot-add">
-                  <i class="fa-solid fa-circle-plus"></i>
-                </div>
-              </div>
-            <% end %>
-        </div>
-      </div>
+      <%= render partial: "suggestion", locals: { trip: @trip, spot_suggestions: @spot_suggestions, spot_suggestion_by_user: @spot_suggestion_by_user } %>
     </turbo-frame>  
     <div class="member-container">
       <div class="member-card-style">

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -55,6 +55,7 @@ ja:
       member-edit: メンバーを編集する
       spot-suggestions: 現在提案されているスポット
       spot_delete: スポットの削除
+      vote-limit: 投票期限まであと
   spots:
     index:
       title: スポット検索ページ

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,9 +5,14 @@ Rails.application.routes.draw do
   }
   get "/homes", to: "homes#index"
   resources :trips do
+    member do
+      get "suggestion"
+      get "vote"
+    end
     resources :spots
     resources :spot_suggestions
   end
+
   root "homes#index"
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
### 概要
turbo-frameを用いた提案フェーズと投票フェーズのページ切り替えを実装しました
これによりユーザーはリンクをクリックするだけで対応するフェーズ画面に切り替えることができます
<img width="456" alt="スクリーンショット 2025-05-13 15 28 20" src="https://github.com/user-attachments/assets/674102c9-1cc9-465e-a4bc-fc40cd6f1a94" />


### 修正内容
1. 提案フェーズと投票フェーズをそれぞれ部分テンプレートファイルに作成(各フェーズで使用するスポット一覧の部分テンプレートも別途作成)
- 投票フェーズ: 'trips/_suggestion.html.erb'
- 投票フェーズ: 'trips/_vote.html.erb'
- スポット一覧: trips/_spot.html.erb

2. 'trips'コントローラに'suggestion'アクションと'vote'アクションを作成
- 'suggestion'アクション : '_suggestion.html.erb'を呼び出す
- 'vote'アクション : '_vote.html.erb'を呼び出す

3. 'suggestion'アクションと'vote'アクションへのルーティングを作成
- member do を用いて'suggestion'アクションと'vote'アクションに対してGETリクエストが送信できるように設定

4. 'trips/show.html.erb'に提案フェーズリンクと投票フェーズリンクを作成
- 提案フェーズリンク：suggestion_trip_path(@trip)
- 投票フェーズリンク：vote_trip_path(@trip)
- どちらのリンクも data: { turbo_frame: "phase" } を付与しております

5. 初期表示として'trips/show.html.erb'に提案フェーズを記述
- 親HTML(trips/show.html.erb)に初期表示として提案フェーズのhtmlを記述

※ 現在表示しているフェーズが一目でわかるように対応するフェーズリンクをハイライトしています

