### PR TITLE
スポット追加のリンク修正

### DIFF
--- a/app/views/trips/_suggestion.html.erb
+++ b/app/views/trips/_suggestion.html.erb
@@ -24,7 +24,7 @@
             <%= t('trips.show.no-spot-suggestions') %>
           </div>
         <% end %>
-        <%= link_to trip_spots_path(trip) do %>
+        <%= link_to trip_spots_path(trip), data: { turbo_frame: "_top"} do %>
           <div class="spot-add-container">
             <div class="spot-add">
               <%= t('trips.show.spot-add')%>


### PR DESCRIPTION
### 概要
turbo-frameタグ内のスポット追加リンクを以下のように修正しました
```
<%= link_to trip_spots_path(trip), data: { turbo_frame: "_top"} do %>
```
これによりページ全体をリロードするため正常なページ遷移を行うことができるようになります
