### PR TITLE
ページネーションのリンクの修正

### DIFF
--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -7,27 +7,27 @@
       </div>
     <% end %>
     <% if @search_results %>
-      <turbo-frame>
+      <turbo-frame id="pagination">
         <%= render partial: "spot", collection: @search_results %>
         <div class="pagination">
           <% if @first_page %>
-            <%= link_to t('.first_page'), trip_spots_path(page: @first_page, keyword: @keyword), class:"page_link", data: { turbo_frame: "_top"} %>
+            <%= link_to t('.first_page'), trip_spots_path(page: @first_page, keyword: @keyword), class:"page_link", data: { turbo_frame: "_pagination"} %>
           <% end %>
           <% if @previous_page %>
-            <%= link_to t('.previous_page'), trip_spots_path(page: @previous_page, keyword: @keyword), class:"page_link", data: { turbo_frame: "_top" } %>
+            <%= link_to t('.previous_page'), trip_spots_path(page: @previous_page, keyword: @keyword), class:"page_link", data: { turbo_frame: "_pagination" } %>
           <% end %>
           <% (1..@total_page).each do |page| %>
             <% if page == @current_page %>
               <span class="current_page_link"><%= @current_page %></span>
             <% else %>
-              <%= link_to page, trip_spots_path(page: page, keyword: @keyword), class:"page_link", data: { turbo_frame: "_top"} %>
+              <%= link_to page, trip_spots_path(page: page, keyword: @keyword), class:"page_link", data: { turbo_frame: "_pagination"} %>
             <% end %>
           <% end %>
           <% if @next_page %>
-            <%= link_to t('.next_page'), trip_spots_path(page: @next_page, keyword: @keyword), class:"page_link", data: { turbo_frame: "_top"} %>
+            <%= link_to t('.next_page'), trip_spots_path(page: @next_page, keyword: @keyword), class:"page_link", data: { turbo_frame: "_pagination"} %>
           <% end %>
           <% if @last_page %>
-            <%= link_to t('.last_page'), trip_spots_path(page: @last_page, keyword: @keyword), class:"page_link", data: { turbo_frame: "_top"} %>
+            <%= link_to t('.last_page'), trip_spots_path(page: @last_page, keyword: @keyword), class:"page_link", data: { turbo_frame: "_pagination"} %>
           <% end %>
         </div>
       </turbo-frame>


### PR DESCRIPTION
### 概要
spots/indexのページネーションにおけるページ遷移を行うリンクに対して'turbo_frame'を指定するように修正しました
```
data: { turbo_frame: "_pagination"}
```
これによりturbo-frameを用いた高速ページリロードができるようになります