### PR TITLE
trip/showのform_withをmodel指定に修正

### DIFF
--- a/app/controllers/spot_suggestions_controller.rb
+++ b/app/controllers/spot_suggestions_controller.rb
@@ -2,13 +2,14 @@ class SpotSuggestionsController < ApplicationController
   def create
     spot_suggestion = SpotSuggestion.new(spot_suggestions_params)
     trip = Trip.find(params[:trip_id])
-    spot = Spot.find(params[:spot_id])
+    spot = Spot.find(params[:spot_suggestion][:spot_id])
+    binding.pry
     if spot_suggestion.save
       flash[:notice] = "スポットの提案に成功しました"
       redirect_to trip_path(trip)
     else
       flash[:alert] = "スポットの提案に失敗しました"
-      redirect_to spot_path(spot)
+      redirect_to trip_spot_path(spot, trip)
     end
   end
 
@@ -27,6 +28,6 @@ class SpotSuggestionsController < ApplicationController
   private
 
   def spot_suggestions_params
-    params.permit(:user_id, :trip_id, :spot_id)
+    params.require(:spot_suggestion).permit(:user_id, :spot_id).merge(trip_id: params[:trip_id])
   end
 end

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -47,6 +47,7 @@ class SpotsController < ApplicationController
   end
 
   def show
+    @trip = Trip.find(params[:trip_id])
     @spot = Spot.find(params[:id])
   end
 end

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -35,9 +35,8 @@
     <%= link_to t(".search_page_link"), :back %>
   </div>
   <div class="spot-submit">
-    <%= form_with url: trip_spot_suggestions_path do |f| %>
+    <%= form_with model: [@trip, SpotSuggestion.new] do |f| %>
       <%= f.hidden_field :user_id, value: current_user.id %>
-      <%= f.hidden_field :trip_id, value: params[:trip_id] %>
       <%= f.hidden_field :spot_id, value: @spot.id  %>
       <%= f.submit t(".spot_suggestions_create"), class:"submit-botton" %>
     <% end %>


### PR DESCRIPTION
### 概要
'trip/show'のformにおいて、DBへの保存を目的としているためmodel指定に変更しました

### 修正内容
1.  formの記述を以下のように修正 
```
form_with model: [@trip, SpotSuggestion.new] do |f|
```
- ネストに合わせて記述

3. 'hidden_field'から'trip_id'を削除
- urlにtrip_idが付与されているため

4. 'spot_suggestions'コントローラのストロングパラメータを以下のように修正
```
    params.require(:spot_suggestion).permit(:user_id, :spot_id).merge(trip_id: params[:trip_id])
```