### PR TITLE
spotsコントローラのindexアクションの処理をモデルに分担

### DIFF
--- a/app/controllers/spot_suggestions_controller.rb
+++ b/app/controllers/spot_suggestions_controller.rb
@@ -3,7 +3,6 @@ class SpotSuggestionsController < ApplicationController
     spot_suggestion = SpotSuggestion.new(spot_suggestions_params)
     trip = Trip.find(params[:trip_id])
     spot = Spot.find(params[:spot_suggestion][:spot_id])
-    binding.pry
     if spot_suggestion.save
       flash[:notice] = "スポットの提案に成功しました"
       redirect_to trip_path(trip)

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -1,49 +1,21 @@
 class SpotsController < ApplicationController
   def index
-    @trip_id = params[:trip_id]
-    return if params[:keyword].blank?
-      keyword = Keyword.search_keyword(params[:keyword])
-      unless keyword
-        spots_data = TextSearch.search_spots(keyword: params[:keyword])
+    word = params[:keyword]
+    return if word.blank?
 
-        # キーワードテーブルのレコードを作成
-        keyword = Keyword.create_keyword(params[:keyword])
-
-        spots_unique_numbers = spots_data.map { |spot_data| spot_data["id"] }
-
-        new_spots = Spot.unregistrated_unique_number(spots_unique_numbers)
-
-        spot_details = new_spots.map do |new_spot|
-          PlaceDetails.search_spot_details(place_id: new_spot)
-        end
-
-        # 最終的にspotsに保存したいすべてのパラメータを記述
-        spot_details_data = spot_details.map do |spot_detail| {
-          unique_number: spot_detail["id"],
-          spot_name: spot_detail.dig("displayName", "text"),
-          URL: spot_detail["websiteUri"],
-          spot_value: spot_detail["rating"],
-          address: spot_detail["formattedAddress"],
-          image_url: "https://places.googleapis.com/v1/#{spot_detail.dig("photos", 0, "name")}/media?maxWidthPx=800&key=#{ENV["API_KEY"]}"
-          }
-        end
-        Spot.bulk_insert(spot_details_data)
-        spots_data = Spot.where(unique_number: spots_unique_numbers)
-        spots_data.each do |spot|
-          KeywordSpot.create_keyword_spot(keyword_id: keyword.id, spot_id: spot.id)
-        end
-      end
-      # ページネーション
-      @keyword = params[:keyword]
-      @current_page = (params[:page].to_i > 0) ? params[:page].to_i : Spot::DEFAULT_PAGE
-      spots = keyword.spots
-      total_spots = spots.count
-      @total_page = (total_spots.to_f / Spot::PER_PAGE).ceil
-      @search_results = spots.offset((@current_page - 1) * Spot::PER_PAGE).limit(Spot::PER_PAGE)
-      @next_page = @current_page * Spot::PER_PAGE < total_spots ? @current_page + 1 : nil
-      @previous_page = @current_page > 1 ? @current_page - 1 : nil
-      @first_page = @current_page > 1 ? Spot::MIN_PAGE : nil
-      @last_page = @current_page * Spot::PER_PAGE < total_spots ? @total_page : nil
+    Keyword.find_by_create_and_spot(word: word)
+    # ページネーション
+    keyword = Keyword.find_by(word: word)
+    @keyword = params[:keyword]
+    @current_page = (params[:page].to_i > 0) ? params[:page].to_i : Spot::DEFAULT_PAGE
+    spots = keyword.spots
+    total_spots = spots.count
+    @total_page = (total_spots.to_f / Spot::PER_PAGE).ceil
+    @search_results = spots.offset((@current_page - 1) * Spot::PER_PAGE).limit(Spot::PER_PAGE)
+    @next_page = @current_page * Spot::PER_PAGE < total_spots ? @current_page + 1 : nil
+    @previous_page = @current_page > 1 ? @current_page - 1 : nil
+    @first_page = @current_page > 1 ? Spot::MIN_PAGE : nil
+    @last_page = @current_page * Spot::PER_PAGE < total_spots ? @total_page : nil
   end
 
   def show

--- a/app/models/keyword.rb
+++ b/app/models/keyword.rb
@@ -2,11 +2,13 @@ class Keyword < ApplicationRecord
   has_many :keyword_spots
   has_many :spots, through: :keyword_spots, dependent: :destroy
 
-  def self.search_keyword(keyword)
-    find_by(word: keyword)
-  end
+  def self.find_by_create_and_spot(word:)
+    keyword = find_by(word: word)
+    unless keyword.present?
+      spots_data = TextSearch.search_spots(keyword: word)
+      keyword = create(word: word)
+      Spot.register_spots(spots_data: spots_data, keyword: keyword)
 
-  def self.create_keyword(keyword)
-    create(word: keyword)
+    end
   end
 end

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -9,13 +9,27 @@ class Spot < ApplicationRecord
   DEFAULT_PAGE = 1
   MIN_PAGE = 1
 
-  # DB未登録のunique_numberのみ抽出するメソッド
-  def self.unregistrated_unique_number(spots_unique_numbers)
-    exist_unique_numbers = where(unique_number: spots_unique_numbers).pluck(:unique_number)
-    spots_unique_numbers - exist_unique_numbers
-  end
+  def self.register_spots(spots_data:, keyword:)
+    spots_unique_numbers = spots_data.map { |spot_data| spot_data["id"] }
+    new_spots = spots_unique_numbers - where(unique_number: spots_unique_numbers).pluck(:unique_number)
+    spot_details = new_spots.map do |new_spot|
+      PlaceDetails.search_spot_details(place_id: new_spot)
+    end
 
-  def self.bulk_insert(spot_details_data)
-    insert_all(spot_details_data)
+    insert_all(
+      spot_details_data = spot_details.map do |spot_detail| {
+        unique_number: spot_detail["id"],
+        spot_name: spot_detail.dig("displayName", "text"),
+        URL: spot_detail["websiteUri"],
+        spot_value: spot_detail["rating"],
+        address: spot_detail["formattedAddress"],
+        image_url: "https://places.googleapis.com/v1/#{spot_detail.dig("photos", 0, "name")}/media?maxWidthPx=800&key=#{ENV["API_KEY"]}"
+        }
+      end
+    )
+    spot_ids = where(unique_number: spots_unique_numbers).ids
+    spot_ids.each do |spot_id|
+      KeywordSpot.create(keyword_id: keyword.id, spot_id: spot_id)
+    end
   end
 end


### PR DESCRIPTION
### 概要
'spots'コントローラにおけるユーザーが入力したキーワードに対してDB内検索またはAPI処理を行うコードを、'spot.rb'と'keyword.rb'に記述することで責務の分離を行いました

---
### 修正内容
1. 'keyword.rb'で以下の処理を実行
- 入力キーワードに対するDB内検索処理
- DB内にデータが存在しなかった場合
  - TextSearchAPIを用いたスポット情報の取得
  - 新規キーワードの保存処理

2. 'spot.rb'で以下の処理を実行
- SpotDetailsAPIを用いたスポット詳細情報の取得
- 取得したデータをDBへ保存処理
- KeywordSpotsテーブルのレコードを作成
