### PR TITLE
spot_suggestionsコントローラの修正

### DIFF
--- a/app/controllers/spot_suggestions_controller.rb
+++ b/app/controllers/spot_suggestions_controller.rb
@@ -1,26 +1,23 @@
 class SpotSuggestionsController < ApplicationController
   def create
     spot_suggestion = SpotSuggestion.new(spot_suggestions_params)
-    trip = Trip.find(params[:trip_id])
-    spot = Spot.find(params[:spot_suggestion][:spot_id])
     if spot_suggestion.save
       flash[:notice] = "スポットの提案に成功しました"
-      redirect_to trip_path(trip)
+      redirect_to trip_path(spot_suggestion.trip_id)
     else
       flash[:alert] = "スポットの提案に失敗しました"
-      redirect_to trip_spot_path(spot, trip)
+      redirect_back fallback_location: trip_spots_path(spot_suggestion.trip_id)
     end
   end
 
   def destroy
-    spot_suggestion = SpotSuggestion.find_by(trip_id: params[:id], spot_id: params[:spot_id])
-    trip = Trip.find(params[:id])
+    spot_suggestion = SpotSuggestion.find_by!(trip_id: params[:id], spot_id: params[:spot_id])
     if spot_suggestion.delete
       flash[:notice] = "スポットの削除が完了しました"
-      redirect_to trip_path(trip)
+      redirect_to trip_path(spot_suggestion.trip_id)
     else
       flash[:alert] = "スポットの削除に失敗しました"
-      redirect_to trip_path(trip)
+      redirect_back fallback_location: trip_path(spot_suggestion.trip_id)
     end
   end
 


### PR DESCRIPTION
### 概要
'spot_suggestions'コントローラの'create'アクションにおいて、'trip_id'を変数'spot_suggestion'から取得するように変更することで、DBへのアクセス回数を減らしました
また'spot_suggestion.save'が失敗した際の処理において、'redirect_back'を利用することで直前のページに遷移するように変更しました
同様に'destroy'アクションの'spot_suggestion.delete'についても同じ変更を行いました

'destroy'アクションで'SpotSuggestion'モデルに対してデータ検索を行う際にnilの場合は例外が発生するように'find_by!'を使うように変更しました

---