### PR TITLE
tripの詳細ページの処理を修正

### DIFF
--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -18,21 +18,20 @@ class TripsController < ApplicationController
 
   def show
     @trip = Trip.find(params[:id])
-    @spot_suggestions = @trip.spots
+    @spot_suggestions = @trip.spot_suggestions
     @spot_suggestion_by_user = SpotSuggestion.where(trip_id: @trip.id).index_by(&:spot_id)
   end
 
   def suggestion
     @trip = Trip.find(params[:id])
-    @spot_suggestions = @trip.spots
-    @spot_suggestion_by_user = SpotSuggestion.where(trip_id: @trip.id).index_by(&:spot_id)
-    render partial: "trips/suggestion", locals: { trip: @trip, spot_suggestions: @spot_suggestions, spot_suggestion_by_user: @spot_suggestion_by_user }
+    @spot_suggestions = @trip.spot_suggestions
+    render partial: "trips/suggestion", locals: { trip: @trip, spot_suggestions: @spot_suggestions }
   end
 
   def vote
     @trip = Trip.find(params[:id])
-    @spot_votes = @trip.spots
-    render partial: "trips/vote", locals: { trip: @trip, spot_votes: @spot_votes }
+    @spot_suggestions = @trip.spot_suggestions
+    render partial: "trips/vote", locals: { trip: @trip, spot_suggestions: @spot_suggestions }
   end
 
   private

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -19,7 +19,6 @@ class TripsController < ApplicationController
   def show
     @trip = Trip.find(params[:id])
     @spot_suggestions = @trip.spot_suggestions
-    @spot_suggestion_by_user = SpotSuggestion.where(trip_id: @trip.id).index_by(&:spot_id)
   end
 
   def suggestion

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -1,7 +1,6 @@
 class Spot < ApplicationRecord
   has_many :spot_suggestions
   has_many :trips, through: :spot_suggestions, dependent: :destroy
-  has_many :users, through: :spot_suggestions
   has_many :keyword_spots
   has_many :keywords, through: :keyword_spots, dependent: :destroy
 

--- a/app/views/trips/_spot.html.erb
+++ b/app/views/trips/_spot.html.erb
@@ -1,7 +1,7 @@
 <div class="spot-image">
   <%= link_to spot_suggestion.spot.spot_name.truncate(8), trip_spot_path(spot_suggestion.spot) %><br>
   <%= image_tag spot_suggestion.spot.image_url, class:"image" %>
-  <% if spot_suggestion.user.id == current_user.id %>
+  <% if show_delete_link && spot_suggestion.user.id == current_user.id %>
     <%= link_to trip_spot_suggestion_path(trip_id: params[:id], spot_id: spot_suggestion.spot.id), method: :delete, data: { confirm: "本当に削除しますか？" }, class:"spot-delete-link" do %>
       <i class="fa-solid fa-xmark"></i>
       <%= t('trips.show.spot_delete')%>

--- a/app/views/trips/_spot.html.erb
+++ b/app/views/trips/_spot.html.erb
@@ -1,8 +1,8 @@
 <div class="spot-image">
-  <%= link_to spot.spot_name.truncate(8), trip_spot_path(spot) %><br>
-  <%= image_tag spot.image_url, class:"image" %>
-  <% if local_assigns[:spot_suggestion_by_user] && spot_suggestion_by_user[spot.id].user_id == current_user.id %>
-    <%= link_to trip_spot_suggestion_path(trip_id: params[:id], spot_id: spot.id), method: :delete, data: { confirm: "本当に削除しますか？" }, class:"spot-delete-link" do %>
+  <%= link_to spot_suggestion.spot.spot_name.truncate(8), trip_spot_path(spot_suggestion.spot) %><br>
+  <%= image_tag spot_suggestion.spot.image_url, class:"image" %>
+  <% if spot_suggestion.user.id == current_user.id %>
+    <%= link_to trip_spot_suggestion_path(trip_id: params[:id], spot_id: spot_suggestion.spot.id), method: :delete, data: { confirm: "本当に削除しますか？" }, class:"spot-delete-link" do %>
       <i class="fa-solid fa-xmark"></i>
       <%= t('trips.show.spot_delete')%>
     <% end %>

--- a/app/views/trips/_suggestion.html.erb
+++ b/app/views/trips/_suggestion.html.erb
@@ -17,7 +17,7 @@
             <%= t("trips.show.spot-suggestions") %>
           </div>
           <div class="spot-image-container">
-            <%= render partial: "spot", collection: spot_suggestions, :as => "spot_suggestion" %>
+            <%= render partial: "spot", collection: spot_suggestions, :as => "spot_suggestion", locals: { show_delete_link: true} %>
           </div>
         <% else %>
           <div class="no-spot-suggestion-vote-headline">

--- a/app/views/trips/_suggestion.html.erb
+++ b/app/views/trips/_suggestion.html.erb
@@ -17,7 +17,7 @@
             <%= t("trips.show.spot-suggestions") %>
           </div>
           <div class="spot-image-container">
-            <%= render partial: "spot", collection: spot_suggestions, :as => "spot", locals: { spot_suggestion_by_user: spot_suggestion_by_user } %>
+            <%= render partial: "spot", collection: spot_suggestions, :as => "spot_suggestion" %>
           </div>
         <% else %>
           <div class="no-spot-suggestion-vote-headline">

--- a/app/views/trips/_vote.html.erb
+++ b/app/views/trips/_vote.html.erb
@@ -12,9 +12,9 @@
       <div class="suggestion-vote-limit">
         <%= t('trips.show.vote-limit') %><%= (trip.spot_vote_limit - Date.today).to_i  %>日
       </div>
-      <% if spot_votes.present? %>
+      <% if spot_suggestions.present? %>
         <div class="spot-image-container">
-          <%= render partial: "spot", collection: spot_votes, :as => "spot" %>
+          <%= render partial: "spot", collection: spot_suggestions, :as => "spot_suggestion" %>
         </div>
       <% else %>
         <div class="no-spot-suggestion-vote-headline">

--- a/app/views/trips/_vote.html.erb
+++ b/app/views/trips/_vote.html.erb
@@ -14,7 +14,7 @@
       </div>
       <% if spot_suggestions.present? %>
         <div class="spot-image-container">
-          <%= render partial: "spot", collection: spot_suggestions, :as => "spot_suggestion" %>
+          <%= render partial: "spot", collection: spot_suggestions, :as => "spot_suggestion", locals: { show_delete_link: false } %>
         </div>
       <% else %>
         <div class="no-spot-suggestion-vote-headline">

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -24,7 +24,7 @@
       </div>
     </div>
     <turbo-frame id="phase">
-      <%= render partial: "suggestion", locals: { trip: @trip, spot_suggestions: @spot_suggestions, spot_suggestion_by_user: @spot_suggestion_by_user } %>
+      <%= render partial: "suggestion", locals: { trip: @trip, spot_suggestions: @spot_suggestions, show_delete_link: true } %>
     </turbo-frame>  
     <div class="member-container">
       <div class="member-card-style">


### PR DESCRIPTION
### 概要
'trips'コントローラの'show','suggestion','vote'アクションにおいて、'@spot_suggestions'の中身を'trip_id'に紐づく'SpotSuggestion'のインスタンスに変更しました
'@spot_suggestions'から'spot'と'user'情報を取得することで、提案されたスポットの情報と、提案したユーザーの情報をより簡単に取得することができるようにしました

### 修正内容
1. '@spot_suggestions'の中身を @trip.spot_suggestionsに変更

2. 提案されたスポットの情報を、繰り返し処理内で'spot_suggestion'経由で取得するように変更
```
  <%= link_to spot_suggestion.spot.spot_name.truncate(8), trip_spot_path(spot_suggestion.spot) %><br>
  <%= image_tag spot_suggestion.spot.image_url, class:"image" %>
```

4. スポットを提案したユーザーの情報を、繰り返し処理内で'spot_suggestion'経由で取得するように変更
```
  <% if show_delete_link && spot_suggestion.user.id == current_user.id %>
```
※上記の条件分岐は、'_suggestion.html.erb'から呼び出された時のみ作動させたいため、'_spot.html.erb'を呼び出す際の'locals'に以下の記述を加えています
```
_suggestionから呼び出す時

locals: { show_delete_link: true}

_voteから呼び出す時

locals: { show_delete_link: false}
```
