### PR TITLE
しおり詳細ページから提案されたスポットの詳細ページへ遷移する際のリンクが正常に作動するように修正

### DIFF
--- a/app/views/trips/_spot.html.erb
+++ b/app/views/trips/_spot.html.erb
@@ -1,5 +1,5 @@
 <div class="spot-image">
-  <%= link_to spot_suggestion.spot.spot_name.truncate(8), trip_spot_path(spot_suggestion.spot) %><br>
+  <%= link_to spot_suggestion.spot.spot_name.truncate(8), trip_spot_path(trip, spot_suggestion.spot), data: { turbo_frame: "_top" } %><br>
   <%= image_tag spot_suggestion.spot.image_url, class:"image" %>
   <% if show_delete_link && spot_suggestion.user.id == current_user.id %>
     <%= link_to trip_spot_suggestion_path(trip_id: params[:id], spot_id: spot_suggestion.spot.id), method: :delete, data: { confirm: "本当に削除しますか？" }, class:"spot-delete-link" do %>

--- a/app/views/trips/_suggestion.html.erb
+++ b/app/views/trips/_suggestion.html.erb
@@ -17,7 +17,7 @@
             <%= t("trips.show.spot-suggestions") %>
           </div>
           <div class="spot-image-container">
-            <%= render partial: "spot", collection: spot_suggestions, :as => "spot_suggestion", locals: { show_delete_link: true} %>
+            <%= render partial: "spot", collection: spot_suggestions, :as => "spot_suggestion", locals: { trip: trip, show_delete_link: true} %>
           </div>
         <% else %>
           <div class="no-spot-suggestion-vote-headline">

--- a/app/views/trips/_vote.html.erb
+++ b/app/views/trips/_vote.html.erb
@@ -14,7 +14,7 @@
       </div>
       <% if spot_suggestions.present? %>
         <div class="spot-image-container">
-          <%= render partial: "spot", collection: spot_suggestions, :as => "spot_suggestion", locals: { show_delete_link: false } %>
+          <%= render partial: "spot", collection: spot_suggestions, :as => "spot_suggestion", locals: { trip: trip, show_delete_link: false } %>
         </div>
       <% else %>
         <div class="no-spot-suggestion-vote-headline">


### PR DESCRIPTION
### 概要
各ユーザーが提案したスポットの詳細ページに遷移するためのリンクに以下の修正を加えました
- turbo-frame内ではなくページ全体を更新するように修正
- ルーティングのネストに合わせてtrip_idパラメータを付与するように修正

---
### 修正内容
**スポット詳細ページへの遷移リンクを以下のように修正**
```
  <%= link_to spot_suggestion.spot.spot_name.truncate(8), trip_spot_path(trip, spot_suggestion.spot), data: { turbo_frame: "_top" } %><br>
```
