### PR TITLE
スポットの提案に失敗した際の処理を修正

### DIFF
--- a/app/controllers/spot_suggestions_controller.rb
+++ b/app/controllers/spot_suggestions_controller.rb
@@ -5,7 +5,7 @@ class SpotSuggestionsController < ApplicationController
       flash[:notice] = "スポットの提案に成功しました"
       redirect_to trip_path(spot_suggestion.trip_id)
     else
-      flash[:alert] = "スポットの提案に失敗しました"
+      flash[:alert] = spot_suggestion.errors.full_messages
       redirect_back fallback_location: trip_spots_path(spot_suggestion.trip_id)
     end
   end

--- a/app/models/spot_suggestion.rb
+++ b/app/models/spot_suggestion.rb
@@ -3,4 +3,6 @@ class SpotSuggestion < ApplicationRecord
   belongs_to :user
   belongs_to :trip
   belongs_to :spot
+
+  validates :trip_id, uniqueness: { scope: :spot_id }
 end


### PR DESCRIPTION
### 概要
'spot_suggestions'コントローラの'create'アクションで'spot_suggestion.save'に失敗した場合、エラーメッセージが表示されるように変更しました。
また'trip_id'と'spot_id'の組み合わせが重複して登録されないように、DBだけでなくモデルにもバリデーションを作成しました。

---
### 修正内容
1. 'spot_suggestions'コントローラの'create'アクションで'spot_suggestion.save'に失敗した場合の記述
```
      flash[:alert] = spot_suggestion.errors.full_messages
```

2. 'SpotSuggestion.rb'に'trip_id'と'spot_id'に関するバリデーションを作成
```
  validates :trip_id, uniqueness: { scope: :spot_id }
```
