### PR TITLE
しおり詳細ページのスポット名の表示を修正

### DIFF
--- a/app/views/trips/_spot.html.erb
+++ b/app/views/trips/_spot.html.erb
@@ -3,7 +3,7 @@
     <%= check_box_tag "spot_suggestion_ids[]", spot_suggestion.id, false  %>
   <% end %>
   
-  <%= link_to spot_suggestion.spot.spot_name.truncate(8), trip_spot_path(trip, spot_suggestion.spot), data: { turbo_frame: "_top" } %><br>
+  <%= link_to spot_suggestion.spot.spot_name.truncate(6, omission: "‥"), trip_spot_path(trip, spot_suggestion.spot), data: { turbo_frame: "_top" } %><br>
   <%= image_tag spot_suggestion.spot.image_url, class:"image" %>
   <% if show_delete_link && spot_suggestion.user.id == current_user.id %>
     <%= link_to trip_spot_suggestion_path(trip_id: params[:id], spot_id: spot_suggestion.spot.id), method: :delete, data: { confirm: "本当に削除しますか？" }, class:"spot-delete-link" do %>


### PR DESCRIPTION
### 概要
しおり詳細ページのスポット名の表示処理を以下のように修正しました
```
<%= link_to spot_suggestion.spot.spot_name.truncate(6, omission: "‥"), trip_spot_path(trip, spot_suggestion.spot), data: { turbo_frame: "_top" } %><br>
```
- ６文字を超えた場合最後の一文字を"‥"に変更

---