### PR TITLE
投票済みとそうでないスポット分けて表示

### DIFF
--- a/app/assets/stylesheets/trips/show.scss
+++ b/app/assets/stylesheets/trips/show.scss
@@ -62,68 +62,97 @@
       width: 500px;
       margin: auto;
       margin-bottom: 50px;
+    
       .suggestion-vote-card-style {
         width: 500px;
         border: 1px solid black;
+    
         .suggestion-vote-limit {
           margin-top: 30px;
+          margin-bottom: 30px;
           color: red;
           text-align: center;
-          font-size: 25px;
+          font-size: 30px;
         }
+    
         .spot-suggestion-vote-headline {
           margin-top: 30px;
           margin-bottom: 30px;
           text-align: center;
-          font-size: 20px;
+          font-size: 30px;
           font-weight: bold;
         }
-        .spot-image-container {
-          display: flex;
-          white-space: nowrap;
-          flex-wrap: wrap;
-          width: 500px;
-          justify-content: center;
-          .spot-image {
-            padding:10px;
-            width: 120px;
-            text-align: center;
-            .image {
-              display: block;
-              width: 120px;
-              height: 120px;
-            }
-            .spot-delete-link {
-              text-decoration: none;
-              font-size: 10px;
-              color: red;
-            }
-          }
-        }
-        .submit-form {
+    
+        .voted-spot-title {
           text-align: center;
-          margin-top: 20px;
+          margin-top: 30px;
           margin-bottom: 30px;
-          .submit-button {
-            font-size: 20px;
-            background-color: #007bff;
-            color: white;
-            border: 1px solid #007bff;
-            border-radius: 4px;
+          font-size: 30px;
+          font-weight: bold;
+        }
+      }
+    
+      .spot-card-style {
+        border: 1px solid black;
+        margin-bottom: 30px;
+      }
+    
+      .spot-image-container {
+        display: flex;
+        white-space: nowrap;
+        flex-wrap: wrap;
+        width: 500px;
+        justify-content: center;
+        margin-bottom: 30px;
+        gap: 20px;
+    
+        .spot-image {
+          border: 1px solid black;
+          padding: 10px;
+          width: 120px;
+          text-align: center;
+    
+          .image {
+            display: block;
+            width: 120px;
+            height: 120px;
+          }
+    
+          .spot-delete-link {
+            text-decoration: none;
+            font-size: 10px;
+            color: red;
           }
         }
       }
+    
+      .submit-form {
+        text-align: center;
+        margin-top: 20px;
+        margin-bottom: 30px;
+    
+        .submit-button {
+          font-size: 20px;
+          background-color: #007bff;
+          color: white;
+          border: 1px solid #007bff;
+          border-radius: 4px;
+        }
+      }
+    
       .no-spot-suggestion-vote-headline {
         margin-top: 100px;
         margin-bottom: 100px;
         text-align: center;
         font-size: 20px;
       }
+    
       .spot-add-container {
         display: flex;
         justify-content: right;
         gap: 5px;
         padding: 10px;
+    
         .spot-add {
           color: blue;
         }

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -30,7 +30,10 @@ class TripsController < ApplicationController
   def vote
     @trip = Trip.find(params[:id])
     @spot_suggestions = @trip.spot_suggestions
-    render partial: "trips/vote", locals: { trip: @trip, spot_suggestions: @spot_suggestions }
+    voted_spot_suggestion_ids = SpotVote.where(trip_id: @trip, user_id: current_user.id).pluck(:spot_suggestion_id)
+    @voted_spot_suggestions = @spot_suggestions.select { |s| voted_spot_suggestion_ids.include?(s.id) }
+    @not_voted_spot_suggestions = @spot_suggestions.reject { |s| voted_spot_suggestion_ids.include?(s.id) }
+    render partial: "trips/vote", locals: { trip: @trip, spot_suggestions: @spot_suggestions, voted_spot_suggestions: @voted_spot_suggestions, not_voted_spot_suggestions: @not_voted_spot_suggestions }
   end
 
   private

--- a/app/views/trips/_spot.html.erb
+++ b/app/views/trips/_spot.html.erb
@@ -2,7 +2,6 @@
   <% if show_check_box %>
     <%= check_box_tag "spot_suggestion_ids[]", spot_suggestion.id, false  %>
   <% end %>
-  
   <%= link_to spot_suggestion.spot.spot_name.truncate(6, omission: "‥"), trip_spot_path(trip, spot_suggestion.spot), data: { turbo_frame: "_top" } %><br>
   <%= image_tag spot_suggestion.spot.image_url, class:"image" %>
   <% if show_delete_link && spot_suggestion.user.id == current_user.id %>

--- a/app/views/trips/_vote.html.erb
+++ b/app/views/trips/_vote.html.erb
@@ -14,8 +14,23 @@
       </div>
       <% if spot_suggestions.present? %>
         <%= form_with url: trip_spot_votes_path(trip), data: { turbo: false } do |f| %>
-          <div class="spot-image-container">
-            <%= render partial: "spot", collection: spot_suggestions, :as => "spot_suggestion", locals: { trip: trip, show_delete_link: false, show_check_box: true } %>
+          <% if voted_spot_suggestions %>
+            <div class="spot-card-style">
+              <div class="voted-spot-title">
+                <%= t('trips.show.voted-spot') %>
+              </div>
+              <div class="spot-image-container">
+                <%= render partial: "spot", collection: voted_spot_suggestions, :as => "spot_suggestion", locals: { trip: trip, show_delete_link: false, show_check_box: false } %>
+              </div>
+            </div>
+          <% end %>
+          <div class="spot-card-style">
+            <div class="spot-suggestion-vote-headline ">
+              <%= t('trips.show.spot-suggestions') %>
+            </div>
+            <div class="spot-image-container">
+              <%= render partial: "spot", collection: not_voted_spot_suggestions, :as => "spot_suggestion", locals: { trip: trip, show_delete_link: false, show_check_box: true } %>
+            </div>
           </div>
           <div class="submit-form">
             <%= f.submit t('trips.show.submit'), class:"submit-button" %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -53,10 +53,11 @@ ja:
       spot-add: スポットを追加する
       member: 参加メンバー
       member-edit: メンバーを編集する
-      spot-suggestions: 現在提案されているスポット
+      spot-suggestions: 提案されているスポット
       spot_delete: スポットの削除
       vote-limit: 投票期限まであと
       submit: 投票する
+      voted-spot: 現在投票しているスポット
   spots:
     index:
       title: スポット検索ページ


### PR DESCRIPTION
### 概要
スポットの投票ページにおけるスポットの表示を、「投票済み」と「投票してない」スポットとで分けて表示することで視覚的に自分が投票したスポットがわかるように変更しました
レイアウトは以下のように変更しています
<img width="446" alt="スクリーンショット 2025-05-16 12 55 26" src="https://github.com/user-attachments/assets/8f00905b-f376-4531-a1d5-1b5134b8c091" />

---
### 修正内容
1. 'trips'コントローラの'vote'アクションに以下のインスタンス変数を作成
- '@voted_spot_suggestions': 提案されたスポットの中で投票済みのスポットのみを抽出
```
@voted_spot_suggestions = @spot_suggestions.select { |s| voted_spot_suggestion_ids.include?(s.id) }
```
- '@not_voted_spot_suggestions': 提案されたスポットの中で投票していないスポットのみを抽出
```
@not_voted_spot_suggestions = @spot_suggestions.reject { |s| voted_spot_suggestion_ids.include?(s.id) }
```
- 'render'の'locals'に以下を追加
```
voted_spot_suggestions: @voted_spot_suggestions, not_voted_spot_suggestions: @not_voted_spot_suggestions
```
2. 'trips/_vote'で'_spot'の呼び出し方を以下のように変更
- 'collection'メソッドで''@voted_spot_suggestions'を用いた'_spot'の表示
- 'collection'メソッドで''@not_voted_spot_suggestions'を用いた'_spot'の表示
