### PR TITLE
trip_usersコントローラとルーティングの作成

### DIFF
--- a/app/controllers/trip_users_controller.rb
+++ b/app/controllers/trip_users_controller.rb
@@ -1,0 +1,25 @@
+class TripUsersController < ApplicationController
+  def index
+    @trip = Trip.find(params[:trip])
+    @trip_users = @trip.trip_users
+  end
+
+  def update
+    member = TripUser.find_by!(trip_id: params[:trip_id], user_id: params[:user_id])
+    current_leader = TripUser.find_by!(trip_id: params[:trip], user_id: current_user.id)
+    current_leader.update!(host: :member)
+    member.update!(host: :leader)
+  end
+
+  def destroy
+    trip_user = TripUser.find_by!(trip_id: params[:trip_id], user_id: params[:user_id])
+    trip = trip_user.trip
+    if trip_user.destroy
+      flash[:notice] = "#{trip.name}から退会しました"
+      redirect_to homes_path
+    else
+      flash[:alert] = "退会できませんでした"
+      redirect_back fallback_location: homes_path
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
     resources :spots
     resources :spot_suggestions
     resources :spot_votes
+    resources :trip_users
   end
 
   root "homes#index"


### PR DESCRIPTION
### 概要
しおりに参加しているユーザーの表示・役割変更・退会処理を行うために必要なコントローラとルーティングを設定しました
これにより参加者の管理機能が実現できます

---
### 修正内容
1. 'trip_users'コントローラに以下のアクションを作成
- 'index': 参加者一覧の表示
- 'update': 参加者の役割の変更
- 'destroy': 指定したユーザーのしおりからの退会

2. ルーティングの作成
- tripsにネストした構造で設定
---