### PR TITLE
tripのタイトル、旅行日程、行き先を部分テンプレートに変更

### DIFF
--- a/app/views/shared/_trip_data.html.erb
+++ b/app/views/shared/_trip_data.html.erb
@@ -1,0 +1,23 @@
+<div class="title">
+  <i class="fa-solid fa-book-open"></i>
+  <%= @trip.title %>
+  <i class="fa-solid fa-book-open"></i>
+</div>
+<div class="trip-detail">
+  <div class="icon-label">
+    <i class="fa-solid fa-calendar-days"></i>
+    <%= Trip.human_attribute_name(:date) %>
+  </div>
+  <div class="trip-info">
+    <%= @trip.date %>
+  </div>
+</div>
+<div class="trip-detail">
+  <div class="icon-label">
+    <i class="fa-solid fa-plane"></i>
+    <%= Trip.human_attribute_name(:distination) %>
+  </div>
+  <div class="trip-info">
+    <%= @trip.distination %>
+  </div>
+</div>

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -1,28 +1,6 @@
 <div class="trips-show">
   <div class="card-style">
-    <div class="title">
-      <i class="fa-solid fa-book-open"></i>
-      <%= @trip.title %>
-      <i class="fa-solid fa-book-open"></i>
-    </div>
-    <div class="trip-detail">
-      <div class="icon-label">
-        <i class="fa-solid fa-calendar-days"></i>
-        <%= Trip.human_attribute_name(:date) %>
-      </div>
-      <div class="trip-info">
-        <%= @trip.date %>
-      </div>
-    </div>
-    <div class="trip-detail">
-      <div class="icon-label">
-        <i class="fa-solid fa-plane"></i>
-        <%= Trip.human_attribute_name(:distination) %>
-      </div>
-      <div class="trip-info">
-        <%= @trip.distination %>
-      </div>
-    </div>
+    <%= render "shared/trip_data" %>
     <turbo-frame id="phase">
       <%= render partial: "suggestion", locals: { trip: @trip, spot_suggestions: @spot_suggestions, show_delete_link: true } %>
     </turbo-frame>  


### PR DESCRIPTION
### 概要
'trip'のタイトル、旅行日程、行き先を共通化するために部分テンプレート("shared/_trip_data")に変更し、trip/showでは"shared/_trip_data"を呼び出して表示するように変更しました
これにより別のページから簡単に'trip'のタイトル、旅行日程、行き先を表示することができるようになります