### PR TITLE
参加メンバーの編集ビューを追加

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,3 +19,4 @@
 @use "trips/show.scss" as trips_show;
 @use "spots/index.scss" as spots_index;
 @use "spots/show.scss" as spots_show;
+@use "trip_users/index.scss" as trip_users_index;

--- a/app/assets/stylesheets/trip_users/index.scss
+++ b/app/assets/stylesheets/trip_users/index.scss
@@ -1,83 +1,92 @@
 .trip-users-index {
-  .trip-data-container {
-    width: 600px;
-    margin: 0 auto;
-    .title {
-      text-align: center;
-      gap: 20px;
-      font-size: 30px;
-      margin-top: 30px;
-      margin-bottom: 30px;
-    }
-    .trip-detail {
-      margin-left: 50px;
-      margin-bottom: 20px;
-      font-size: 20px;
-      .icon-label {
-        display: flex;
-        align-items: center;
-        gap: 10px;
-      }
-      .trip-info {
-        display: flex;
-        align-items: center;
-        padding: 10px;
-        width: 300px;
-        height: 40px;
-        border: 1px solid #ddd;
-        border-radius: 8px;
-        box-shadow: 0 4px 9px rgba(0,0,0,0.1);
-      }
-    }
-  }
   .card-style {
     margin: 0 auto;
     margin-top: 100px;
     margin-bottom: 100px;
-    width: 500px;
+    width: 600px;
     border: 1px solid #ddd;
     border-radius: 8px;
     box-shadow: 0 4px 9px rgba(0,0,0,0.1);
-    .title {
-      text-align: center;
-      margin-top: 30px;
-      margin-bottom: 30px;
-      font-size: 25px;
-      font-weight: bold;
-    }
-    .container {
-      display: flex;
+    .trip-data-container {
+      width: 600px;
       margin: 0 auto;
+      .title {
+        text-align: center;
+        gap: 20px;
+        font-size: 30px;
+        margin-top: 30px;
+        margin-bottom: 30px;
+      }
+      .trip-detail {
+        margin-left: 50px;
+        margin-bottom: 20px;
+        font-size: 20px;
+        .icon-label {
+          display: flex;
+          align-items: center;
+          gap: 10px;
+        }
+        .trip-info {
+          display: flex;
+          align-items: center;
+          padding: 10px;
+          width: 300px;
+          height: 40px;
+          border: 1px solid #ddd;
+          border-radius: 8px;
+          box-shadow: 0 4px 9px rgba(0,0,0,0.1);
+        }
+      }
+    }
+    .trip-users-card-style {
+      margin: 0 auto;
+      margin-top: 100px;
+      margin-bottom: 100px;
       width: 500px;
-      align-items: center;
-      margin-bottom: 30px;
-      .icon-name-container {
+      border: 1px solid #ddd;
+      border-radius: 8px;
+      box-shadow: 0 4px 9px rgba(0,0,0,0.1);
+      .title {
+        text-align: center;
+        margin-top: 30px;
+        margin-bottom: 30px;
+        font-size: 25px;
+        font-weight: bold;
+      }
+      .container {
         display: flex;
-        width: 100%;
+        margin: 0 auto;
+        width: 500px;
         align-items: center;
-        margin-left: 10px;
-        gap: 20px;
-        .crown-icon {
-          color: yellow;
-          width: 40px;
-          flex-shrink: 0;
+        margin-bottom: 30px;
+        .icon-name-container {
+          display: flex;
+          width: 100%;
+          align-items: center;
+          margin-left: 10px;
+          gap: 20px;
+          .crown-icon {
+            color: yellow;
+            width: 40px;
+            flex-shrink: 0;
+          }
+          .user-icon {
+            width: 40px;
+            flex-shrink: 0;
+            margin-left: 5px;
+          }
+          .user-name {
+            font-size: 20px;
+          }
+         }
+        .update-delete-container {
+          display: flex;
+          justify-content: right;
+          align-items: center;
+          margin-right: 15px;
+          width: 400px;
+          gap: 20px;
         }
-        .user-icon {
-          width: 40px;
-          flex-shrink: 0;
-          margin-left: 5px;
-        }
-        .user-name {
-          font-size: 20px;
-        }
-       }
-      .update-delete-container {
-        display: flex;
-        justify-content: right;
-        align-items: center;
-        margin-right: 15px;
-        width: 400px;
-        gap: 20px;
       }
     }
   }

--- a/app/assets/stylesheets/trip_users/index.scss
+++ b/app/assets/stylesheets/trip_users/index.scss
@@ -1,0 +1,84 @@
+.trip-users-index {
+  .trip-data-container {
+    width: 600px;
+    margin: 0 auto;
+    .title {
+      text-align: center;
+      gap: 20px;
+      font-size: 30px;
+      margin-top: 30px;
+      margin-bottom: 30px;
+    }
+    .trip-detail {
+      margin-left: 50px;
+      margin-bottom: 20px;
+      font-size: 20px;
+      .icon-label {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+      .trip-info {
+        display: flex;
+        align-items: center;
+        padding: 10px;
+        width: 300px;
+        height: 40px;
+        border: 1px solid #ddd;
+        border-radius: 8px;
+        box-shadow: 0 4px 9px rgba(0,0,0,0.1);
+      }
+    }
+  }
+  .card-style {
+    margin: 0 auto;
+    margin-top: 100px;
+    margin-bottom: 100px;
+    width: 500px;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    box-shadow: 0 4px 9px rgba(0,0,0,0.1);
+    .title {
+      text-align: center;
+      margin-top: 30px;
+      margin-bottom: 30px;
+      font-size: 25px;
+      font-weight: bold;
+    }
+    .container {
+      display: flex;
+      margin: 0 auto;
+      width: 500px;
+      align-items: center;
+      margin-bottom: 30px;
+      .icon-name-container {
+        display: flex;
+        width: 100%;
+        align-items: center;
+        margin-left: 10px;
+        gap: 20px;
+        .crown-icon {
+          color: yellow;
+          width: 40px;
+          flex-shrink: 0;
+        }
+        .user-icon {
+          width: 40px;
+          flex-shrink: 0;
+          margin-left: 5px;
+        }
+        .user-name {
+          font-size: 20px;
+        }
+       }
+      .update-delete-container {
+        display: flex;
+        justify-content: right;
+        align-items: center;
+        margin-right: 15px;
+        width: 400px;
+        gap: 20px;
+      }
+    }
+  }
+}

--- a/app/controllers/trip_users_controller.rb
+++ b/app/controllers/trip_users_controller.rb
@@ -1,21 +1,24 @@
 class TripUsersController < ApplicationController
   def index
-    @trip = Trip.find(params[:trip])
+    @trip = Trip.find(params[:trip_id])
     @trip_users = @trip.trip_users
+    @current_user_trip_user = @trip_users.find_by(user_id: current_user.id)
   end
 
-  def update
-    member = TripUser.find_by!(trip_id: params[:trip_id], user_id: params[:user_id])
-    current_leader = TripUser.find_by!(trip_id: params[:trip], user_id: current_user.id)
+  def change_leader
+    member = TripUser.find(params[:id])
+    current_leader = TripUser.find_by!(trip_id: params[:trip_id], user_id: current_user.id)
     current_leader.update!(host: :member)
     member.update!(host: :leader)
+
+    redirect_back fallback_location: homes_path
   end
 
   def destroy
-    trip_user = TripUser.find_by!(trip_id: params[:trip_id], user_id: params[:user_id])
+    trip_user = TripUser.find(params[:id])
     trip = trip_user.trip
     if trip_user.destroy
-      flash[:notice] = "#{trip.name}から退会しました"
+      flash[:notice] = "#{trip.title}から退会しました"
       redirect_to homes_path
     else
       flash[:alert] = "退会できませんでした"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_many :trip_users
-  has_many :users, through: :trip_users, dependent: :destroy
+  has_many :trips, through: :trip_users, dependent: :destroy
   has_many :spot_suggestions
   has_many :spot_vote
   has_one_attached :avatar
@@ -21,10 +21,10 @@ class User < ApplicationRecord
   end
 
   def trips_in_progress
-    Trip.where(status: :in_progress)
+    trips.where(status: :in_progress)
   end
 
   def trips_past
-    Trip.where(status: :completed)
+    trips.where(status: :completed)
   end
 end

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -75,3 +75,5 @@
     </div>
   </div>
 </div>
+
+<%= link_to t('.logout'), destroy_user_session_path, method: :delete, data: { confirm: "本当に削除しますか？" }%>

--- a/app/views/shared/_trip_data.html.erb
+++ b/app/views/shared/_trip_data.html.erb
@@ -1,6 +1,6 @@
 <div class="title">
   <i class="fa-solid fa-book-open"></i>
-  <%= @trip.title %>
+  <%= trip.title %>
   <i class="fa-solid fa-book-open"></i>
 </div>
 <div class="trip-detail">
@@ -9,7 +9,7 @@
     <%= Trip.human_attribute_name(:date) %>
   </div>
   <div class="trip-info">
-    <%= @trip.date %>
+    <%= trip.date %>
   </div>
 </div>
 <div class="trip-detail">
@@ -18,6 +18,6 @@
     <%= Trip.human_attribute_name(:distination) %>
   </div>
   <div class="trip-info">
-    <%= @trip.distination %>
+    <%= trip.distination %>
   </div>
 </div>

--- a/app/views/trip_users/index.html.erb
+++ b/app/views/trip_users/index.html.erb
@@ -29,7 +29,7 @@
                <i class="fa-solid fa-xmark"></i>
                <%= t('.delete') %>
              <% end %>
-           <% elsif trip_user.user_id == current_user.id && trip_user.id != current_user.id %>
+           <% elsif trip_user.user_id == current_user.id && trip_user.member? %>
              <%= link_to trip_trip_user_path(trip_id: @trip.id, id: trip_user.id), method: :delete, data: { confirm: "本当に削除しますか？" } do%>
                <i class="fa-solid fa-xmark"></i>
                <%= t('.exit') %>

--- a/app/views/trip_users/index.html.erb
+++ b/app/views/trip_users/index.html.erb
@@ -1,0 +1,41 @@
+<div class="trip-users-index">
+  <div class="trip-data-container">
+    <%= render "shared/trip_data", trip: @trip  %>
+  </div>
+  <div class="card-style">
+    <div class="title">
+      <%= t('.title') %>
+    </div>
+    <% @trip_users.each do |trip_user| %>
+      <div class="container">
+        <div class="icon-name-container">
+          <% if trip_user.leader? %>
+            <i class="fa-solid fa-crown crown-icon fa-2x"></i>
+          <% else %>
+            <i class="fa-solid fa-user user-icon fa-2x"></i>
+          <% end %>
+          <div class="user-name">
+            <%= trip_user.user.name %>
+          </div>
+        </div>
+        <div class="update-delete-container">
+          <% if @current_user_trip_user.leader? && trip_user.id != current_user.id  %>
+            <%= link_to change_leader_trip_trip_user_path(trip_id: @trip.id, id: trip_user.id ), data: { confirm: "本当に変更しますか？"} do %>
+              <i class="fa-solid fa-crown member-icon fa-lg"></i>
+              <%= t('.update-leader') %>
+            <% end %>
+            <%= link_to trip_trip_user_path(trip_id: @trip.id, id: trip_user.id), method: :delete, data: { confirm: "本当に削除しますか？" } do %>
+              <i class="fa-solid fa-xmark"></i>
+              <%= t('.delete') %>
+            <% end %>
+          <% elsif trip_user.user_id == current_user.id && trip_user.id != current_user.id %>
+            <%= link_to trip_trip_user_path(trip_id: @trip.id, id: trip_user.id), method: :delete, data: { confirm: "本当に削除しますか？" } do%>
+              <i class="fa-solid fa-xmark"></i>
+              <%= t('.exit') %>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/trip_users/index.html.erb
+++ b/app/views/trip_users/index.html.erb
@@ -1,41 +1,42 @@
 <div class="trip-users-index">
-  <div class="trip-data-container">
-    <%= render "shared/trip_data", trip: @trip  %>
-  </div>
   <div class="card-style">
-    <div class="title">
-      <%= t('.title') %>
-    </div>
-    <% @trip_users.each do |trip_user| %>
-      <div class="container">
-        <div class="icon-name-container">
-          <% if trip_user.leader? %>
-            <i class="fa-solid fa-crown crown-icon fa-2x"></i>
-          <% else %>
-            <i class="fa-solid fa-user user-icon fa-2x"></i>
-          <% end %>
-          <div class="user-name">
-            <%= trip_user.user.name %>
-          </div>
-        </div>
-        <div class="update-delete-container">
-          <% if @current_user_trip_user.leader? && trip_user.id != current_user.id  %>
-            <%= link_to change_leader_trip_trip_user_path(trip_id: @trip.id, id: trip_user.id ), data: { confirm: "本当に変更しますか？"} do %>
-              <i class="fa-solid fa-crown member-icon fa-lg"></i>
-              <%= t('.update-leader') %>
-            <% end %>
-            <%= link_to trip_trip_user_path(trip_id: @trip.id, id: trip_user.id), method: :delete, data: { confirm: "本当に削除しますか？" } do %>
-              <i class="fa-solid fa-xmark"></i>
-              <%= t('.delete') %>
-            <% end %>
-          <% elsif trip_user.user_id == current_user.id && trip_user.id != current_user.id %>
-            <%= link_to trip_trip_user_path(trip_id: @trip.id, id: trip_user.id), method: :delete, data: { confirm: "本当に削除しますか？" } do%>
-              <i class="fa-solid fa-xmark"></i>
-              <%= t('.exit') %>
-            <% end %>
-          <% end %>
-        </div>
-      </div>
-    <% end %>
-  </div>
+   <div class="trip-data-container">
+     <%= render "shared/trip_data", trip: @trip  %>
+   </div>
+   <div class="trip-users-card-style">
+     <div class="title">
+       <%= t('.title') %>
+     </div>
+     <% @trip_users.each do |trip_user| %>
+       <div class="container">
+         <div class="icon-name-container">
+           <% if trip_user.leader? %>
+             <i class="fa-solid fa-crown crown-icon fa-2x"></i>
+           <% else %>
+             <i class="fa-solid fa-user user-icon fa-2x"></i>
+           <% end %>
+           <div class="user-name">
+             <%= trip_user.user.name %>
+           </div>
+         </div>
+         <div class="update-delete-container">
+           <% if @current_user_trip_user.leader? && trip_user.id != current_user.id  %>
+             <%= link_to change_leader_trip_trip_user_path(trip_id: @trip.id, id: trip_user.id ), data: { confirm: "本当に変更しますか？"} do %>
+               <i class="fa-solid fa-crown member-icon fa-lg"></i>
+               <%= t('.update-leader') %>
+             <% end %>
+             <%= link_to trip_trip_user_path(trip_id: @trip.id, id: trip_user.id), method: :delete, data: { confirm: "本当に削除しますか？" } do %>
+               <i class="fa-solid fa-xmark"></i>
+               <%= t('.delete') %>
+             <% end %>
+           <% elsif trip_user.user_id == current_user.id && trip_user.id != current_user.id %>
+             <%= link_to trip_trip_user_path(trip_id: @trip.id, id: trip_user.id), method: :delete, data: { confirm: "本当に削除しますか？" } do%>
+               <i class="fa-solid fa-xmark"></i>
+               <%= t('.exit') %>
+             <% end %>
+           <% end %>
+         </div>
+       </div>
+     <% end %>
+   </div>
 </div>

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -1,6 +1,6 @@
 <div class="trips-show">
   <div class="card-style">
-    <%= render "shared/trip_data" %>
+    <%= render "shared/trip_data", trip: @trip %>
     <turbo-frame id="phase">
       <%= render partial: "suggestion", locals: { trip: @trip, spot_suggestions: @spot_suggestions, show_delete_link: true } %>
     </turbo-frame>  
@@ -18,7 +18,7 @@
           </div>
         <% end %>
         <div class="member-edit-link">
-          <%= link_to t('.member-edit'), class:"member-edit" %>
+          <%= link_to t('.member-edit'), trip_trip_users_path(@trip), class:"member-edit" %>
         </div>
       </div>
     </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -69,3 +69,9 @@ ja:
     show:
       search_page_link: 検索ページに戻る
       spot_suggestions_create: スポットを提案する
+  trip_users:
+    index:
+      title: 参加メンバー
+      update-leader: 幹事にする
+      delete: 削除する
+      exit: 退会する

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,11 @@ Rails.application.routes.draw do
     resources :spots
     resources :spot_suggestions
     resources :spot_votes
-    resources :trip_users
+    resources :trip_users do
+      member do
+        get "change_leader"
+      end
+    end
   end
 
   root "homes#index"


### PR DESCRIPTION
### 概要
参加メンバーの役割変更や退会処理などをおこなう画面を追加しました
これによりしおりごとに参加メンバーの管理を行うことができます
レイアウトは以下になります
- ログインしているユーザーがリーダーの時
<img width="610" alt="スクリーンショット 2025-05-17 15 52 03" src="https://github.com/user-attachments/assets/fbd3e7df-05c8-43dc-80f9-2cc64190a7d4" />
- ログインしているユーザーがメンバーの時
<img width="502" alt="スクリーンショット 2025-05-17 15 58 50" src="https://github.com/user-attachments/assets/321ea76e-6f67-4fdc-b6ce-bbe82b3b4202" />

---
### 修正内容
1.  しおりに参加しているメンバーの名前と役割アイコン(leaderは王冠、memberは人)を表示

2. ログインしているユーザーがリーダーの場合は他のユーザーに対して以下の操作リンクを追加
- 指定したユーザーをリーダーに変更
- 指定したユーザーを削除する

3. ログインしているユーザーがメンバーの場合は自分に対して以下の操作リンクを追加
- 退会する
