### PR TITLE
homes/indexのレイアウト修正

### DIFF
--- a/app/assets/stylesheets/homes/index.scss
+++ b/app/assets/stylesheets/homes/index.scss
@@ -3,7 +3,6 @@
     margin: 0 auto;
     margin-top: 50px;
     margin-bottom: 100px;
-    padding: 20px;
     width: 600px;
     border: 1px solid #ddd;
     border-radius: 8px;
@@ -53,10 +52,13 @@
     }
     .trips-container {
       display: flex;
-      justify-content: space-between;
+      width: 600px;
+      margin: 0 auto;
+      gap: 10px;
+      flex-wrap: wrap;
       .trips-card-style {
         margin: 0 auto;
-        width: 200px;
+        width: 190px;
         border: 1px solid black;
         box-shadow: 0 4px 9px rgba(0,0,0,0.1);
         .trip-link {
@@ -77,8 +79,24 @@
           font-weight: bold;
         }
         .member-list {
-          text-align: center;
-          margin-bottom: 20px;
+          margin-left: 20px;
+          display: flex;
+          align-items: center;
+          width: 170px;
+          gap: 10px;
+          .crown-icon {
+            color: yellow;
+            width: 20px;
+            text-align: center;
+            display: inline-block;
+            flex-shrink: 0;
+          }
+          .user-icon {
+            width: 20px;
+            text-align: center;
+            display: inline-block;
+            flex-shrink: 0;
+          }
         }
       }
     }

--- a/app/assets/stylesheets/trip_users/index.scss
+++ b/app/assets/stylesheets/trip_users/index.scss
@@ -78,7 +78,7 @@
           .user-name {
             font-size: 20px;
           }
-         }
+        }
         .update-delete-container {
           display: flex;
           justify-content: right;

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -32,7 +32,7 @@
                   <%= t.title %>
                 </div>
                 <% if t.image.attached? %>
-                  <%= image_tag t.image.variant(resize_to_fill: [200,130]) %>
+                  <%= image_tag t.image.variant(resize_to_fill: [190,130]) %>
                 <% end %>
                 <div class="member">
                   <%= t('.member')%>
@@ -40,7 +40,9 @@
                 <% t.trip_users.each do |trip_user| %>
                   <div class="member-list">
                     <% if trip_user.host == "leader" %>
-                      <i class="fa-solid fa-crown"></i>
+                      <i class="fa-solid fa-crown crown-icon "></i>
+                    <% else %>
+                      <i class="fa-solid fa-user user-icon "></i>  
                     <% end %>
                     <%= trip_user.user.name %>
                   </div>


### PR DESCRIPTION
### 概要
homes/indexの以下の部分のレイアウトを修正しました
 - メンバーの表示方法
 - 進行中のしおりの表示方法

<img width="561" alt="スクリーンショット 2025-05-19 9 39 34" src="https://github.com/user-attachments/assets/9978b1ff-43f9-45bd-9b77-b9e4124bb678" />

---
### 修正内容
1. メンバー表示の修正
- リーダーには王冠アイコン、メンバーにはユーザーアイコンが表示されるように修正
- ユーザー名が8文字を超える場合は自動で折り返すように修正

2. 進行中のしおり表示の修正
- ３つごとに自動で折り返すように修正
