### PR TITLE
trip/showのメンバー表示を修正

### DIFF
--- a/app/assets/stylesheets/trips/show.scss
+++ b/app/assets/stylesheets/trips/show.scss
@@ -173,12 +173,25 @@
           font-weight: bold;
           margin-bottom: 10px;
         }
-        .member-icon {
-          color: yellow;
-        }
-        .member-name {
-          font-size: 20px;
-          margin-left: 30px;
+        .member-list {
+          margin-left: 20px;
+          display: flex;
+          align-items: center;
+          width: 270px;
+          gap: 10px;
+          .crown-icon {
+            color: yellow;
+            width: 20px;
+            text-align: center;
+            display: inline-block;
+            flex-shrink: 0;
+          }
+          .user-icon {
+            width: 20px;
+            text-align: center;
+            display: inline-block;
+            flex-shrink: 0;
+          }
         }
         .member-edit-link {
           text-align: right;

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -10,9 +10,11 @@
           <%= t('.member') %>
         </div>
         <% @trip.trip_users.each do |trip_user| %>
-          <div class="member-name">
+          <div class="member-list">
             <% if trip_user.host == "leader" %>
-              <i class="fa-solid fa-crown member-icon"></i>
+              <i class="fa-solid fa-crown crown-icon "></i>
+            <% else %>
+              <i class="fa-solid fa-user user-icon "></i>  
             <% end %>
             <%= trip_user.user.name %>
           </div>


### PR DESCRIPTION
### 概要
しおり詳細ページにおける参加メンバーの表示を以下のように修正しました
- 一定文字数を超えたら自動で折り返すように修正
- リーダーには王冠アイコンを、それ以外のメンバーにはユーザーアイコンを表示

<img width="587" alt="スクリーンショット 2025-05-19 10 13 10" src="https://github.com/user-attachments/assets/5e208e79-086d-46e0-a48f-fe15bedb5121" />
