### PR TITLE
しおり詳細ページの修正

### DIFF
--- a/app/assets/stylesheets/trip_users/index.scss
+++ b/app/assets/stylesheets/trip_users/index.scss
@@ -2,7 +2,7 @@
   .card-style {
     margin: 0 auto;
     margin-top: 100px;
-    margin-bottom: 100px;
+    margin-bottom: 20px;
     width: 600px;
     border: 1px solid #ddd;
     border-radius: 8px;
@@ -89,5 +89,11 @@
         }
       }
     }
+  }
+  .trip-show-link {
+    width: 600px;
+    margin: 0 auto;
+    text-align: right;
+    margin-bottom: 100px;
   }
 }

--- a/app/assets/stylesheets/trips/show.scss
+++ b/app/assets/stylesheets/trips/show.scss
@@ -7,7 +7,6 @@
     border: 1px solid #ddd;
     border-radius: 8px;
     box-shadow: 0 4px 9px rgba(0, 0, 0, 0.1);
-
     .title {
       text-align: center;
       gap: 20px;
@@ -15,18 +14,15 @@
       margin-top: 30px;
       margin-bottom: 30px;
     }
-
     .trip-detail {
       margin-left: 50px;
       margin-bottom: 20px;
       font-size: 20px;
-
       .icon-label {
         display: flex;
         align-items: center;
         gap: 10px;
       }
-
       .trip-info {
         display: flex;
         align-items: center;
@@ -38,25 +34,21 @@
         box-shadow: 0 4px 9px rgba(0, 0, 0, 0.1);
       }
     }
-
     .label-container {
       display: flex;
       text-align: center;
       width: 500px;
       margin: auto;
       margin-top: 70px;
-
       .suggestion-vote-link {
         border: 1px solid black;
         width: 250px;
       }
-
       .suggestion-vote-hilight-link {
         background-color: #99FFFF;
         border: 1px solid black;
         width: 250px;
       }
-
       .suggestion-vote-link a,
       .suggestion-vote-hilight-link a {
         font-size: 20px;
@@ -65,17 +57,14 @@
         text-decoration: none;
       }
     }
-
     .suggestion-vote-container {
       display: flex;
       width: 500px;
       margin: auto;
       margin-bottom: 50px;
-
       .suggestion-vote-card-style {
         width: 500px;
         border: 1px solid black;
-
         .suggestion-vote-limit {
           margin-top: 30px;
           margin-bottom: 30px;
@@ -83,7 +72,6 @@
           text-align: center;
           font-size: 30px;
         }
-
         .spot-suggestion-vote-headline {
           margin-top: 30px;
           margin-bottom: 30px;
@@ -91,7 +79,6 @@
           font-size: 30px;
           font-weight: bold;
         }
-
         .voted-spot-title {
           text-align: center;
           margin-top: 30px;
@@ -99,12 +86,10 @@
           font-size: 30px;
           font-weight: bold;
         }
-
         .spot-card-style {
           border: 1px solid black;
           margin-bottom: 30px;
         }
-
         .spot-image-container {
           display: flex;
           white-space: nowrap;
@@ -113,19 +98,16 @@
           justify-content: center;
           margin-bottom: 30px;
           gap: 20px;
-
           .spot-image {
             border: 1px solid black;
             padding: 10px;
             width: 120px;
             text-align: center;
-
             .image {
               display: block;
               width: 120px;
               height: 120px;
             }
-
             .spot-delete-link {
               text-decoration: none;
               font-size: 10px;
@@ -133,12 +115,10 @@
             }
           }
         }
-
         .submit-form {
           text-align: center;
           margin-top: 20px;
           margin-bottom: 30px;
-
           .submit-button {
             font-size: 20px;
             background-color: #007bff;
@@ -152,52 +132,44 @@
           font-size: 20px;
           margin-bottom: 50px;
         }
-
         .no-spot-suggestion-vote-headline {
           margin-top: 100px;
           margin-bottom: 100px;
           text-align: center;
           font-size: 20px;
         }
-
         .spot-add-container {
           display: flex;
           justify-content: right;
           gap: 5px;
           padding: 10px;
-
           .spot-add {
             color: blue;
           }
         }
       }
     }
-
     .member-container {
       display: flex;
       justify-content: center;
       margin-bottom: 100px;
-
       .member-card-style {
         width: 300px;
         border: 1px solid black;
         border-radius: 8px;
         padding: 10px;
-
         .member-title {
           text-align: center;
           font-size: 25px;
           font-weight: bold;
           margin-bottom: 10px;
         }
-
         .member-list {
           margin-left: 20px;
           display: flex;
           align-items: center;
           width: 270px;
           gap: 10px;
-
           .crown-icon {
             color: yellow;
             width: 20px;
@@ -205,7 +177,6 @@
             display: inline-block;
             flex-shrink: 0;
           }
-
           .user-icon {
             width: 20px;
             text-align: center;
@@ -213,12 +184,10 @@
             flex-shrink: 0;
           }
         }
-
         .member-edit-link {
           text-align: right;
           margin-top: 20px;
           font-size: 13px;
-
           .member-edit {
             color: blue;
           }

--- a/app/assets/stylesheets/trips/show.scss
+++ b/app/assets/stylesheets/trips/show.scss
@@ -6,7 +6,8 @@
     width: 600px;
     border: 1px solid #ddd;
     border-radius: 8px;
-    box-shadow: 0 4px 9px rgba(0,0,0,0.1);
+    box-shadow: 0 4px 9px rgba(0, 0, 0, 0.1);
+
     .title {
       text-align: center;
       gap: 20px;
@@ -14,15 +15,18 @@
       margin-top: 30px;
       margin-bottom: 30px;
     }
+
     .trip-detail {
       margin-left: 50px;
       margin-bottom: 20px;
       font-size: 20px;
+
       .icon-label {
         display: flex;
         align-items: center;
         gap: 10px;
       }
+
       .trip-info {
         display: flex;
         align-items: center;
@@ -31,24 +35,28 @@
         height: 40px;
         border: 1px solid #ddd;
         border-radius: 8px;
-        box-shadow: 0 4px 9px rgba(0,0,0,0.1);
+        box-shadow: 0 4px 9px rgba(0, 0, 0, 0.1);
       }
     }
+
     .label-container {
       display: flex;
       text-align: center;
       width: 500px;
       margin: auto;
       margin-top: 70px;
+
       .suggestion-vote-link {
         border: 1px solid black;
         width: 250px;
       }
+
       .suggestion-vote-hilight-link {
         background-color: #99FFFF;
         border: 1px solid black;
         width: 250px;
       }
+
       .suggestion-vote-link a,
       .suggestion-vote-hilight-link a {
         font-size: 20px;
@@ -57,16 +65,17 @@
         text-decoration: none;
       }
     }
+
     .suggestion-vote-container {
       display: flex;
       width: 500px;
       margin: auto;
       margin-bottom: 50px;
-    
+
       .suggestion-vote-card-style {
         width: 500px;
         border: 1px solid black;
-    
+
         .suggestion-vote-limit {
           margin-top: 30px;
           margin-bottom: 30px;
@@ -74,7 +83,7 @@
           text-align: center;
           font-size: 30px;
         }
-    
+
         .spot-suggestion-vote-headline {
           margin-top: 30px;
           margin-bottom: 30px;
@@ -82,7 +91,7 @@
           font-size: 30px;
           font-weight: bold;
         }
-    
+
         .voted-spot-title {
           text-align: center;
           margin-top: 30px;
@@ -90,95 +99,105 @@
           font-size: 30px;
           font-weight: bold;
         }
-      }
-    
-      .spot-card-style {
-        border: 1px solid black;
-        margin-bottom: 30px;
-      }
-    
-      .spot-image-container {
-        display: flex;
-        white-space: nowrap;
-        flex-wrap: wrap;
-        width: 500px;
-        justify-content: center;
-        margin-bottom: 30px;
-        gap: 20px;
-    
-        .spot-image {
+
+        .spot-card-style {
           border: 1px solid black;
-          padding: 10px;
-          width: 120px;
-          text-align: center;
-    
-          .image {
-            display: block;
+          margin-bottom: 30px;
+        }
+
+        .spot-image-container {
+          display: flex;
+          white-space: nowrap;
+          flex-wrap: wrap;
+          width: 500px;
+          justify-content: center;
+          margin-bottom: 30px;
+          gap: 20px;
+
+          .spot-image {
+            border: 1px solid black;
+            padding: 10px;
             width: 120px;
-            height: 120px;
-          }
-    
-          .spot-delete-link {
-            text-decoration: none;
-            font-size: 10px;
-            color: red;
+            text-align: center;
+
+            .image {
+              display: block;
+              width: 120px;
+              height: 120px;
+            }
+
+            .spot-delete-link {
+              text-decoration: none;
+              font-size: 10px;
+              color: red;
+            }
           }
         }
-      }
-    
-      .submit-form {
-        text-align: center;
-        margin-top: 20px;
-        margin-bottom: 30px;
-    
-        .submit-button {
+
+        .submit-form {
+          text-align: center;
+          margin-top: 20px;
+          margin-bottom: 30px;
+
+          .submit-button {
+            font-size: 20px;
+            background-color: #007bff;
+            color: white;
+            border: 1px solid #007bff;
+            border-radius: 4px;
+          }
+        }
+        .not-voted-spot {
+          text-align: center;
           font-size: 20px;
-          background-color: #007bff;
-          color: white;
-          border: 1px solid #007bff;
-          border-radius: 4px;
+          margin-bottom: 50px;
         }
-      }
-    
-      .no-spot-suggestion-vote-headline {
-        margin-top: 100px;
-        margin-bottom: 100px;
-        text-align: center;
-        font-size: 20px;
-      }
-    
-      .spot-add-container {
-        display: flex;
-        justify-content: right;
-        gap: 5px;
-        padding: 10px;
-    
-        .spot-add {
-          color: blue;
+
+        .no-spot-suggestion-vote-headline {
+          margin-top: 100px;
+          margin-bottom: 100px;
+          text-align: center;
+          font-size: 20px;
+        }
+
+        .spot-add-container {
+          display: flex;
+          justify-content: right;
+          gap: 5px;
+          padding: 10px;
+
+          .spot-add {
+            color: blue;
+          }
         }
       }
     }
+
     .member-container {
       display: flex;
       justify-content: center;
       margin-bottom: 100px;
+
       .member-card-style {
         width: 300px;
         border: 1px solid black;
         border-radius: 8px;
         padding: 10px;
+
         .member-title {
           text-align: center;
           font-size: 25px;
           font-weight: bold;
           margin-bottom: 10px;
         }
+
         .member-list {
           margin-left: 20px;
           display: flex;
           align-items: center;
           width: 270px;
           gap: 10px;
+
           .crown-icon {
             color: yellow;
             width: 20px;
@@ -186,6 +205,7 @@
             display: inline-block;
             flex-shrink: 0;
           }
+
           .user-icon {
             width: 20px;
             text-align: center;
@@ -193,13 +213,15 @@
             flex-shrink: 0;
           }
         }
+
         .member-edit-link {
           text-align: right;
           margin-top: 20px;
           font-size: 13px;
-        }
-        .member-edit {
-          color: blue;
+
+          .member-edit {
+            color: blue;
+          }
         }
       }
     }

--- a/app/views/trip_users/index.html.erb
+++ b/app/views/trip_users/index.html.erb
@@ -1,42 +1,46 @@
 <div class="trip-users-index">
   <div class="card-style">
-   <div class="trip-data-container">
-     <%= render "shared/trip_data", trip: @trip  %>
-   </div>
-   <div class="trip-users-card-style">
-     <div class="title">
-       <%= t('.title') %>
-     </div>
-     <% @trip_users.each do |trip_user| %>
-       <div class="container">
-         <div class="icon-name-container">
-           <% if trip_user.leader? %>
-             <i class="fa-solid fa-crown crown-icon fa-2x"></i>
-           <% else %>
-             <i class="fa-solid fa-user user-icon fa-2x"></i>
-           <% end %>
-           <div class="user-name">
-             <%= trip_user.user.name %>
-           </div>
-         </div>
-         <div class="update-delete-container">
-           <% if @current_user_trip_user.leader? && trip_user.id != current_user.id  %>
-             <%= link_to change_leader_trip_trip_user_path(trip_id: @trip.id, id: trip_user.id ), data: { confirm: "本当に変更しますか？"} do %>
-               <i class="fa-solid fa-crown member-icon fa-lg"></i>
-               <%= t('.update-leader') %>
-             <% end %>
-             <%= link_to trip_trip_user_path(trip_id: @trip.id, id: trip_user.id), method: :delete, data: { confirm: "本当に削除しますか？" } do %>
-               <i class="fa-solid fa-xmark"></i>
-               <%= t('.delete') %>
-             <% end %>
-           <% elsif trip_user.user_id == current_user.id && trip_user.member? %>
-             <%= link_to trip_trip_user_path(trip_id: @trip.id, id: trip_user.id), method: :delete, data: { confirm: "本当に削除しますか？" } do%>
-               <i class="fa-solid fa-xmark"></i>
-               <%= t('.exit') %>
-             <% end %>
-           <% end %>
-         </div>
-       </div>
-     <% end %>
-   </div>
+    <div class="trip-data-container">
+      <%= render "shared/trip_data", trip: @trip  %>
+    </div>
+    <div class="trip-users-card-style">
+      <div class="title">
+        <%= t('.title') %>
+      </div>
+      <% @trip_users.each do |trip_user| %>
+        <div class="container">
+          <div class="icon-name-container">
+            <% if trip_user.leader? %>
+              <i class="fa-solid fa-crown crown-icon fa-2x"></i>
+            <% else %>
+              <i class="fa-solid fa-user user-icon fa-2x"></i>
+            <% end %>
+            <div class="user-name">
+              <%= trip_user.user.name %>
+            </div>
+          </div>
+          <div class="update-delete-container">
+            <% if @current_user_trip_user.leader? && trip_user.id != current_user.id  %>
+              <%= link_to change_leader_trip_trip_user_path(trip_id: @trip.id, id: trip_user.id ), data: { confirm: "本当に変更しますか？"} do %>
+                <i class="fa-solid fa-crown member-icon fa-lg"></i>
+                <%= t('.update-leader') %>
+              <% end %>
+              <%= link_to trip_trip_user_path(trip_id: @trip.id, id: trip_user.id), method: :delete, data: { confirm: "本当に削除しますか？" } do %>
+                <i class="fa-solid fa-xmark"></i>
+                <%= t('.delete') %>
+              <% end %>
+            <% elsif trip_user.user_id == current_user.id && trip_user.member? %>
+              <%= link_to trip_trip_user_path(trip_id: @trip.id, id: trip_user.id), method: :delete, data: { confirm: "本当に削除しますか？" } do%>
+                <i class="fa-solid fa-xmark"></i>
+                <%= t('.exit') %>
+              <% end %>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+  <div class="trip-show-link">
+    <%= link_to t('.trip_show'), trip_path(@trip)%>
+  </div>
 </div>

--- a/app/views/trips/_vote.html.erb
+++ b/app/views/trips/_vote.html.erb
@@ -19,9 +19,15 @@
               <div class="voted-spot-title">
                 <%= t('trips.show.voted-spot') %>
               </div>
-              <div class="spot-image-container">
-                <%= render partial: "spot", collection: voted_spot_suggestions, :as => "spot_suggestion", locals: { trip: trip, show_delete_link: false, show_check_box: false } %>
-              </div>
+              <% if voted_spot_suggestions.present? %>
+                <div class="spot-image-container">
+                  <%= render partial: "spot", collection: voted_spot_suggestions, :as => "spot_suggestion", locals: { trip: trip, show_delete_link: false, show_check_box: false } %>
+                </div>
+              <% else %>
+                <div class="not-voted-spot">
+                  <%= t('trips.show.not-voted-spot') %>
+                </div>
+              <% end %>
             </div>
           <% end %>
           <div class="spot-card-style">

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -58,6 +58,7 @@ ja:
       vote-limit: 投票期限まであと
       submit: 投票する
       voted-spot: 現在投票しているスポット
+      not-voted-spot: まだ投票していません
   spots:
     index:
       title: スポット検索ページ
@@ -75,3 +76,4 @@ ja:
       update-leader: 幹事にする
       delete: 削除する
       exit: 退会する
+      trip_show: しおり詳細ページに戻る

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -58,7 +58,7 @@ ja:
       vote-limit: 投票期限まであと
       submit: 投票する
       voted-spot: 現在投票しているスポット
-      not-voted-spot: まだ投票していません
+      not-voted-spot: まだ投票したスポットはありません
   spots:
     index:
       title: スポット検索ページ


### PR DESCRIPTION
### 概要
投票フェーズにおいて、まだ投票を行っていない場合は「まだ投票したスポットはありません」と表示するように変更しました
また、メンバー編集画面において、しおり詳細ページへ戻るリンクを作成しました
- 投票を行っていない場合のレイアウト
<img width="408" alt="スクリーンショット 2025-05-19 15 39 05" src="https://github.com/user-attachments/assets/55c178f2-d713-4f11-a5bc-ec34f888e3d4" />

- メンバー編集画面におけるレイアウト
<img width="557" alt="スクリーンショット 2025-05-19 15 45 18" src="https://github.com/user-attachments/assets/37a84fce-3003-4d10-a7c1-f392e140f7ad" />

---
### 修正内容
1. '_vote.html.erb'において、'voted_spot_suggestions.present?'がfalseの場合は「まだ投票したスポットはありません」と表示されるように修正

2. 'trip_users/index.html.erb'において、しおり詳細ページへ戻るリンクを作成