### PR TITLE
vote_resultの作成

### DIFF
--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -19,6 +19,9 @@ class TripsController < ApplicationController
   def show
     @trip = Trip.find(params[:id])
     @spot_suggestions = @trip.spot_suggestions
+    spot_votes = @trip.spot_votes.pluck(:spot_suggestion_id)
+    ng_spot = spot_votes.group_by { |s| s }.select { |_, value| value.size >= 2 }.keys
+    @voted_result = @spot_suggestions.reject { |spot| ng_spot.include?(spot.id) }
   end
 
   def suggestion

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -7,7 +7,7 @@ class Trip < ApplicationRecord
   has_many :users, through: :trip_users, dependent: :destroy
   has_many :spot_suggestions
   has_many :spots, through: :spot_suggestions, dependent: :destroy
-  has_many :spot_vote
+  has_many :spot_votes
   has_one_attached :image
 
   enum :status, { in_progress: 0, completed: 1 }


### PR DESCRIPTION
### 概要
@voted_resultに提案されたスポットの中から2票以上投票されたスポットを排除した結果を格納する処理を追加しました。
これによりNG投票の結果を表示することができます
※NGにする際の票数はとりあえず2票に設定しており、まだ検討中です。

---
### 修正内容
1. 'spot_votes'に投票されたスポットの'spot_suggestion_id'を格納
2. 'ng_spot'に、同じ'spot_suggestion_id'が 2票以上存在する ID を格納。
3. '@voted_result'に'@spot_suggestions'から'ng_spot'を排除した結果を格納