### PR TITLE
トランザクション処理の導入

### DIFF
--- a/app/controllers/spot_votes_controller.rb
+++ b/app/controllers/spot_votes_controller.rb
@@ -1,18 +1,11 @@
 class SpotVotesController < ApplicationController
   def create
     suggestion_ids = params[:spot_suggestion_ids]
-    spot_suggestion_duplication = false
-    Array(suggestion_ids).each do |suggestion_id|
-      begin
-        SpotVote.create!(trip_id: params[:trip_id], spot_suggestion_id: suggestion_id, user_id: current_user.id)
-      rescue ActiveRecord::RecordNotUnique
-        spot_suggestion_duplication = true
-      end
-    end
-    if spot_suggestion_duplication
-      flash[:alert] = "すでに投票されています"
-    else
+    begin
+      SpotVote.register(trip_id: params[:trip_id], suggestion_ids: suggestion_ids, user_id: current_user.id)
       flash[:notice] = "投票しました"
+    rescue ActiveRecord::RecordNotUnique
+      flash[:alert] = "すでに投票されています"
     end
     redirect_to trip_path(params[:trip_id])
   end

--- a/app/controllers/trip_users_controller.rb
+++ b/app/controllers/trip_users_controller.rb
@@ -6,11 +6,9 @@ class TripUsersController < ApplicationController
   end
 
   def change_leader
-    member = TripUser.find(params[:id])
-    current_leader = TripUser.find_by!(trip_id: params[:trip_id], user_id: current_user.id)
-    current_leader.update!(host: :member)
-    member.update!(host: :leader)
-
+    new_leader = TripUser.find(params[:id])
+    TripUser.change_leader(new_leader_id: new_leader.id, trip_id: params[:trip_id], user_id: current_user.id)
+    flash[:notice] = "#{new_leader.user.name}さんが幹事になりました"
     redirect_back fallback_location: homes_path
   end
 

--- a/app/models/keyword.rb
+++ b/app/models/keyword.rb
@@ -3,12 +3,13 @@ class Keyword < ApplicationRecord
   has_many :spots, through: :keyword_spots, dependent: :destroy
 
   def self.find_by_create_and_spot(word:)
-    keyword = find_by(word: word)
-    unless keyword.present?
-      spots_data = TextSearch.search_spots(keyword: word)
-      keyword = create!(word: word)
-      Spot.register_spots(spots_data: spots_data, keyword: keyword)
-
+    transaction do
+      keyword = find_by(word: word)
+      unless keyword.present?
+        spots_data = TextSearch.search_spots(keyword: word)
+        keyword = create!(word: word)
+        Spot.register_spots(spots_data: spots_data, keyword: keyword)
+      end
     end
   end
 end

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -14,7 +14,6 @@ class Spot < ApplicationRecord
     spot_details = new_spots.map do |new_spot|
       PlaceDetails.search_spot_details(place_id: new_spot)
     end
-
     insert_all!(
       spot_details_data = spot_details.map do |spot_detail| {
         unique_number: spot_detail["id"],

--- a/app/models/spot_vote.rb
+++ b/app/models/spot_vote.rb
@@ -2,4 +2,16 @@ class SpotVote < ApplicationRecord
   belongs_to :user
   belongs_to :trip
   belongs_to :spot_suggestion
+
+  def self.register(trip_id:, suggestion_ids:, user_id:)
+    transaction do
+      Array(suggestion_ids).each do |suggestion_id|
+        SpotVote.create!(
+          trip_id: trip_id,
+          spot_suggestion_id: suggestion_id,
+          user_id: user_id
+        )
+      end
+    end
+  end
 end

--- a/app/models/trip_user.rb
+++ b/app/models/trip_user.rb
@@ -4,4 +4,13 @@ class TripUser < ApplicationRecord
 
   enum :host, { member: 0, leader: 1 }
   validates :host, presence: true
+
+  def self.change_leader(new_leader_id:, trip_id:, user_id:)
+    transaction do
+      current_leader = find_by!(trip_id: trip_id, user_id: user_id)
+      new_leader = find(new_leader_id)
+      current_leader.update!(host: :member)
+      new_leader.update!(host: :leader)
+    end
+  end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -10,7 +10,7 @@ Rails.application.configure do
   config.eager_load = false
 
   # Show full error reports.
-  config.consider_all_requests_local = false
+  config.consider_all_requests_local = true
 
   # Enable server timing.
   config.server_timing = true


### PR DESCRIPTION
### 概要
以下の処理に対してトランザクション処理を導入しました
- 検索されたキーワードに対してDB検索またはAPI検索を行う処理
- 幹事の変更処理
- スポット投票処理

---
### 修正内容
1. "keyword.rb"の"find_or_create_and_spot"メソッドに対してトランザクション処理を導入

2. 幹事変更処理を"trip_user.rb"で行い、トランザクション処理を導入

3. スポット投票処理を"spot_vote.rb"で行い、トランザクション処理を導入
  - 'rescue ActiveRecord::RecordNotUnique'を用いて重複エラーが起きた場合は"すでに投票しています"と表示されるように変更