### PR TITLE
提案期限/投票期限に応じた画面切り替えを実装

### DIFF
--- a/app/assets/stylesheets/trips/show.scss
+++ b/app/assets/stylesheets/trips/show.scss
@@ -86,6 +86,20 @@
           font-size: 30px;
           font-weight: bold;
         }
+        .vote-result-title {
+          text-align: center;
+          margin-top: 20px;
+          margin-bottom: 20px;
+          color: red;
+          font-size: 35px;
+          font-weight: bold;
+        }
+        .vote-result-headline {
+          text-align: center;
+          margin-bottom: 30px;
+          font-size: 25px;
+          font-weight: bold;
+        }
         .spot-card-style {
           border: 1px solid black;
           margin-bottom: 30px;

--- a/app/views/trips/_suggestion.html.erb
+++ b/app/views/trips/_suggestion.html.erb
@@ -9,21 +9,28 @@
   </div>
   <div class="suggestion-vote-container">
     <div class="suggestion-vote-card-style">
+      <% if trip.spot_suggestion_limit > Date.today %>
         <div class="suggestion-vote-limit">
           <%= t('trips.show.suggestion-limit') %><%= (trip.spot_suggestion_limit - Date.today).to_i %>日
         </div>
-        <% if spot_suggestions.present? %>
-          <div class="spot-suggestion-vote-headline">
-            <%= t("trips.show.spot-suggestions") %>
-          </div>
-          <div class="spot-image-container">
-            <%= render partial: "spot", collection: spot_suggestions, :as => "spot_suggestion", locals: { trip: trip, show_delete_link: true, show_check_box: false} %>
-          </div>
-        <% else %>
-          <div class="no-spot-suggestion-vote-headline">
-            <%= t('trips.show.no-spot-suggestions') %>
-          </div>
-        <% end %>
+      <% else %>
+        <div class="suggestion-vote-limit">
+          <%= t('trips.show.suggestion-end') %>
+        </div>
+      <% end %>
+      <% if spot_suggestions.present? %>
+        <div class="spot-suggestion-vote-headline">
+          <%= t("trips.show.spot-suggestions") %>
+        </div>
+        <div class="spot-image-container">
+          <%= render partial: "spot", collection: spot_suggestions, :as => "spot_suggestion", locals: { trip: trip, show_delete_link: true, show_check_box: false} %>
+        </div>
+      <% else %>
+        <div class="no-spot-suggestion-vote-headline">
+          <%= t('trips.show.no-spot-suggestions') %>
+        </div>
+      <% end %>
+      <% if trip.spot_suggestion_limit > Date.today %>
         <%= link_to trip_spots_path(trip), data: { turbo_frame: "_top"} do %>
           <div class="spot-add-container">
             <div class="spot-add">
@@ -34,6 +41,7 @@
             </div>
           </div>
         <% end %>
+      <% end %>
     </div>
   </div>
 </turbo-frame>

--- a/app/views/trips/_vote_result.html.erb
+++ b/app/views/trips/_vote_result.html.erb
@@ -1,0 +1,13 @@
+<div class="suggestion-vote-container">
+  <div class="suggestion-vote-card-style">
+    <div class="vote-result-title">
+      <%= t('trips.show.vote-result')%>
+    </div>
+    <div class="vote-result-headline">
+      <%= t('trips.show.vote-result-headline') %>
+    </div>
+    <div class="spot-image-container">
+      <%= render partial: "spot", collection: voted_result, :as => "spot_suggestion", locals: { trip: trip, show_delete_link: false, show_check_box: false} %>
+    </div>
+  </div>
+</div>

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -2,7 +2,7 @@
   <div class="card-style">
     <%= render "shared/trip_data", trip: @trip %>
       <turbo-frame id="phase">
-        <% if @trip.spot_suggestion_limit > Date.today || @trip.spot_vote_limit > Date.today %>
+        <% if @trip.spot_vote_limit > Date.today %>
           <%= render partial: "suggestion", locals: { trip: @trip, spot_suggestions: @spot_suggestions, show_delete_link: true } %>
         <% else %>
           <%= render partial: "vote_result", locals: { trip: @trip, voted_result: @voted_result } %>

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -1,9 +1,13 @@
 <div class="trips-show">
   <div class="card-style">
     <%= render "shared/trip_data", trip: @trip %>
-    <turbo-frame id="phase">
-      <%= render partial: "suggestion", locals: { trip: @trip, spot_suggestions: @spot_suggestions, show_delete_link: true } %>
-    </turbo-frame>  
+      <turbo-frame id="phase">
+        <% if @trip.spot_suggestion_limit > Date.today || @trip.spot_vote_limit > Date.today %>
+          <%= render partial: "suggestion", locals: { trip: @trip, spot_suggestions: @spot_suggestions, show_delete_link: true } %>
+        <% else %>
+          <%= render partial: "vote_result", locals: { trip: @trip, voted_result: @voted_result } %>
+        <% end %>
+      </turbo-frame>
     <div class="member-container">
       <div class="member-card-style">
         <div class="member-title">

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -49,6 +49,7 @@ ja:
       suggestion-phase: 提案フェーズ
       vote-phase: 投票フェーズ
       suggestion-limit: 提案期限まであと
+      suggestion-end: 提案期間が終了しました
       no-spot-suggestions: スポットが提案されていません
       spot-add: スポットを追加する
       member: 参加メンバー
@@ -59,6 +60,8 @@ ja:
       submit: 投票する
       voted-spot: 現在投票しているスポット
       not-voted-spot: まだ投票したスポットはありません
+      vote-result: 投票結果
+      vote-result-headline: 以下のスポットが選ばれました
   spots:
     index:
       title: スポット検索ページ


### PR DESCRIPTION
### 概要
提案期限/投票期限に応じて適切な画面が表示されるように変更しました

- 提案期限前
<img width="445" alt="スクリーンショット 2025-05-21 16 20 30" src="https://github.com/user-attachments/assets/9b061b1d-353e-4558-a65c-834f4c6e557d" />

- 提案期限後 - 投票期限前
<img width="454" alt="スクリーンショット 2025-05-21 16 19 37" src="https://github.com/user-attachments/assets/602ceb96-efdb-44db-81c3-94bea52bf234" />

<img width="387" alt="スクリーンショット 2025-05-21 16 20 39" src="https://github.com/user-attachments/assets/d46d5bcf-5f82-48f7-98a7-726cc8f72954" />

- 投票期限後
<img width="440" alt="スクリーンショット 2025-05-21 16 21 44" src="https://github.com/user-attachments/assets/e4c82921-b2eb-4084-b26d-070690c425a1" />

---
### 修正内容
1. 投票期限を超えている場合は'_vote_result'を表示するように変更
```
        <% if @trip.spot_vote_limit > Date.today %>
          <%= render partial: "suggestion", locals: { trip: @trip, spot_suggestions: @spot_suggestions, show_delete_link: true } %>
        <% else %>
          <%= render partial: "vote_result", locals: { trip: @trip, voted_result: @voted_result } %>
        <% end %>
```

2. 提案期限後-投票期限前の場合は提案フェーズで提案ができないように変更
```
<% if trip.spot_suggestion_limit > Date.today %>
        <%= link_to trip_spots_path(trip), data: { turbo_frame: "_top"} do %>
          <div class="spot-add-container">
            <div class="spot-add">
              <%= t('trips.show.spot-add')%>
            </div>
            <div class="spot-add">
              <i class="fa-solid fa-circle-plus"></i>
            </div>
          </div>
        <% end %>
      <% end %>
```
