### PR TITLE
メンバー表示の変更

### DIFF
--- a/app/assets/stylesheets/homes/index.scss
+++ b/app/assets/stylesheets/homes/index.scss
@@ -91,6 +91,13 @@
             display: inline-block;
             flex-shrink: 0;
           }
+          .current-user-icon {
+            width: 20px;
+            text-align: center;
+            display: inline-block;
+            flex-shrink: 0;
+            color: blue;
+          }
           .user-icon {
             width: 20px;
             text-align: center;

--- a/app/assets/stylesheets/trip_users/index.scss
+++ b/app/assets/stylesheets/trip_users/index.scss
@@ -70,6 +70,12 @@
             width: 40px;
             flex-shrink: 0;
           }
+          .current-user-icon {
+            width: 40px;
+            flex-shrink: 0;
+            margin-left: 5px;
+            color: blue;
+          }
           .user-icon {
             width: 40px;
             flex-shrink: 0;

--- a/app/assets/stylesheets/trips/show.scss
+++ b/app/assets/stylesheets/trips/show.scss
@@ -191,6 +191,13 @@
             display: inline-block;
             flex-shrink: 0;
           }
+          .current-user-icon {
+            width: 20px;
+            text-align: center;
+            display: inline-block;
+            flex-shrink: 0;
+            color: blue;
+          }
           .user-icon {
             width: 20px;
             text-align: center;

--- a/app/controllers/trip_users_controller.rb
+++ b/app/controllers/trip_users_controller.rb
@@ -1,8 +1,8 @@
 class TripUsersController < ApplicationController
   def index
     @trip = Trip.find(params[:trip_id])
-    @trip_users = @trip.trip_users
-    @current_user_trip_user = @trip_users.find_by(user_id: current_user.id)
+    @trip_users = TripUser.leader_first(trip: @trip)
+    @current_user_trip_user = @trip.trip_users.find_by(user_id: current_user.id)
   end
 
   def change_leader

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -18,6 +18,7 @@ class TripsController < ApplicationController
 
   def show
     @trip = Trip.find(params[:id])
+    @trip_users = TripUser.leader_first(trip: @trip)
     @spot_suggestions = @trip.spot_suggestions
     spot_votes = @trip.spot_votes.pluck(:spot_suggestion_id)
     ng_spot = spot_votes.group_by { |s| s }.select { |_, value| value.size >= 2 }.keys

--- a/app/models/trip_user.rb
+++ b/app/models/trip_user.rb
@@ -13,4 +13,11 @@ class TripUser < ApplicationRecord
       new_leader.update!(host: :leader)
     end
   end
+
+  def self.leader_first(trip:)
+    trip_users = trip.trip_users.to_a
+    leader = trip_users.find { |trip_user| trip_user.host == "leader" }
+    trip_users.delete(leader)
+    trip_users.unshift(leader)
+  end
 end

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -37,12 +37,14 @@
                 <div class="member">
                   <%= t('.member')%>
                 </div>
-                <% t.trip_users.each do |trip_user| %>
+                <% t.trip_users.sort_by { |a| a.host == "leader" ? 0 : 1 }.each do |trip_user| %>
                   <div class="member-list">
                     <% if trip_user.host == "leader" %>
                       <i class="fa-solid fa-crown crown-icon "></i>
+                    <% elsif trip_user.user.id == current_user.id %>
+                      <i class="fa-solid fa-user current-user-icon "></i>  
                     <% else %>
-                      <i class="fa-solid fa-user user-icon "></i>  
+                      <i class="fa-solid fa-user user-icon "></i>
                     <% end %>
                     <%= trip_user.user.name %>
                   </div>

--- a/app/views/trip_users/index.html.erb
+++ b/app/views/trip_users/index.html.erb
@@ -12,6 +12,8 @@
           <div class="icon-name-container">
             <% if trip_user.leader? %>
               <i class="fa-solid fa-crown crown-icon fa-2x"></i>
+            <% elsif trip_user.user.id == current_user.id %>
+              <i class="fa-solid fa-user current-user-icon fa-2x"></i>
             <% else %>
               <i class="fa-solid fa-user user-icon fa-2x"></i>
             <% end %>

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -13,12 +13,14 @@
         <div class="member-title">
           <%= t('.member') %>
         </div>
-        <% @trip.trip_users.each do |trip_user| %>
+        <% @trip_users.each do |trip_user| %>
           <div class="member-list">
             <% if trip_user.host == "leader" %>
               <i class="fa-solid fa-crown crown-icon "></i>
+            <% elsif trip_user.user_id == current_user.id %>
+              <i class="fa-solid fa-user current-user-icon "></i>
             <% else %>
-              <i class="fa-solid fa-user user-icon "></i>  
+              <i class="fa-solid fa-user user-icon "></i>
             <% end %>
             <%= trip_user.user.name %>
           </div>


### PR DESCRIPTION
### 概要
しおりに参加しているメンバーの一覧表示を行う際に、「リーダー」が先頭に来るように変更しました。またログインしているユーザーのアイコンが青色でハイライトされるように変更しました

---
### 修正内容
1. 'trip_user.rb'に「リーダー」が先頭に来るように修正する処理を行う'leader_first'メソッドを作成
```
  def self.leader_first(trip:)
    trip_users = trip.trip_users.to_a
    leader = trip_users.find { |trip_user| trip_user.host == "leader" }
    trip_users.delete(leader)
    trip_users.unshift(leader)
  end
```

2. 'homes/index'でsort_byを用いて「リーダー」が先頭に来るように変更
```
  <% t.trip_users.sort_by { |a| a.host == "leader" ? 0 : 1 }.each do |trip_user| %>
```