### PR TITLE
trip_users/indexの参加メンバー一覧の表示における条件式を修正

### DIFF
--- a/app/controllers/trip_users_controller.rb
+++ b/app/controllers/trip_users_controller.rb
@@ -1,8 +1,9 @@
 class TripUsersController < ApplicationController
   def index
     @trip = Trip.find(params[:trip_id])
+    # @trip_usersは配列化している
     @trip_users = TripUser.leader_first(trip: @trip)
-    @current_user_trip_user = @trip.trip_users.find_by(user_id: current_user.id)
+    @current_user_trip_user = @trip_users.find { |trip_user| trip_user.user_id == current_user.id }
   end
 
   def change_leader

--- a/app/views/trip_users/index.html.erb
+++ b/app/views/trip_users/index.html.erb
@@ -22,7 +22,7 @@
             </div>
           </div>
           <div class="update-delete-container">
-            <% if @current_user_trip_user.leader? && trip_user.id != current_user.id  %>
+            <% if @current_user_trip_user.leader? && trip_user.user_id != current_user.id  %>
               <%= link_to change_leader_trip_trip_user_path(trip_id: @trip.id, id: trip_user.id ), data: { confirm: "本当に変更しますか？"} do %>
                 <i class="fa-solid fa-crown member-icon fa-lg"></i>
                 <%= t('.update-leader') %>


### PR DESCRIPTION
### 概要
以下の修正を行うことで'trip_users'の'user_id'と'current_user.id'を正しく比較することができるようになりました

修正前
```
<% if @current_user_trip_user.leader? && trip_user.id != current_user.id  %>
```

修正後
```
<% if @current_user_trip_user.leader? && trip_user.user_id != current_user.id  %>
```


また、@current_usersを以下のように取得することでDBへのアクセス回数を減らすことができます
```
 @current_user_trip_user = @trip_users.find { |trip_user| trip_user.user_id == current_user.id }
```

---