### PR TITLE
メソッド名の修正

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -3,7 +3,7 @@ class SpotsController < ApplicationController
     word = params[:keyword]
     return if word.blank?
 
-    Keyword.find_or_create_and_spot(word: word)
+    Keyword.find_or_create_keyword_and_fetch_spots(word: word)
     # ページネーション
     keyword = Keyword.find_by(word: word)
     @keyword = params[:keyword]

--- a/app/models/keyword.rb
+++ b/app/models/keyword.rb
@@ -2,7 +2,7 @@ class Keyword < ApplicationRecord
   has_many :keyword_spots
   has_many :spots, through: :keyword_spots, dependent: :destroy
 
-  def self.find_or_create_and_spot(word:)
+  def self.find_or_create_keyword_and_fetch_spots(word:)
     transaction do
       keyword = find_by(word: word)
       unless keyword.present?


### PR DESCRIPTION
### 概要
以下の処理を行うメソッドの名前を'find_or_create_keyword_and_fetch_spots'に変更しました
入力されたワードに対してDB内検索を実施
- ヒットした場合: 処理終了
- ヒットしなかった場合
  - keywordモデルにワードを登録
  - そのワードを元にplaces apiを叩く
  - レスポンスを用いてspotsテーブルにデータを登録