### PR TITLE
transaction処理の修正

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -3,7 +3,15 @@ class SpotsController < ApplicationController
     word = params[:keyword]
     return if word.blank?
 
-    Keyword.find_or_create_keyword_and_fetch_spots(word: word)
+    begin
+      ActiveRecord::Base.transaction do
+        Keyword.find_or_create_keyword_and_fetch_spots(word: word)
+      end
+    rescue
+      flash[:alert]  = "正しく検索を行うことができませんでした。再度検索を行ってください"
+      redirect_back fallback_location: homes_path and return
+    end
+
     # ページネーション
     keyword = Keyword.find_by(word: word)
     @keyword = params[:keyword]

--- a/app/models/keyword.rb
+++ b/app/models/keyword.rb
@@ -3,13 +3,11 @@ class Keyword < ApplicationRecord
   has_many :spots, through: :keyword_spots, dependent: :destroy
 
   def self.find_or_create_keyword_and_fetch_spots(word:)
-    transaction do
-      keyword = find_by(word: word)
-      unless keyword.present?
-        spots_data = TextSearch.search_spots(keyword: word)
-        keyword = create!(word: word)
-        Spot.register_spots(spots_data: spots_data, keyword: keyword)
-      end
+    keyword = find_by(word: word)
+    unless keyword.present?
+      spots_data = TextSearch.search_spots(keyword: word)
+      keyword = create!(word: word)
+      Spot.register_spots(spots_data: spots_data, keyword: keyword)
     end
   end
 end


### PR DESCRIPTION
### 概要
スポット検索機能において、transaction処理内で例外が起きた際は、'redirect_back'を実行するように修正しました。
また以下の記述のように'and return'により'redirect'した段階で処理が終了するようにしています
```
    begin
      ActiveRecord::Base.transaction do
        Keyword.find_or_create_keyword_and_fetch_spots(word: word)
      end
    rescue
      flash[:alert]  = "正しく検索を行うことができませんでした。再度検索を行ってください"
      redirect_back fallback_location: homes_path and return
    end
```
