### PR TITLE
seed.rbの修正

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,10 +10,6 @@
 
 require "csv"
 
-CSV.foreach("db/seed_files/genres.csv") do |row|
-Genre.create!(name: row[0], category_id: row[1])
-end
-
 Category.create!(name: "sightseeing", stay_time: 90)
 Category.create!(name: "shopping", stay_time: 60)
 Category.create!(name: "leisure_land", stay_time: 300)
@@ -24,3 +20,7 @@ Category.create!(name: "other")
 Transportation.create!(name: "車")
 Transportation.create!(name: "電車")
 Transportation.create!(name: "自転車")
+
+CSV.foreach("db/seed_files/genres.csv") do |row|
+  Genre.create!(name: row[0], category_id: row[1])
+end


### PR DESCRIPTION
### 概要
'Genres'テーブルに'category_id'カラムがあり外部キー制約を設けているため、'Categories'テーブルのレコードが存在しないと'Genres'テーブルを作成しようとした際にエラーが発生します。
そのため先に'Categories'テーブルのレコードを作成するように処理順を変更しました