### PR TITLE
スポット検索における'insert_all_data'の修正

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -7,7 +7,7 @@ class SpotsController < ApplicationController
       ActiveRecord::Base.transaction do
         Keyword.find_or_create_keyword_and_fetch_spots(word: word)
       end
-    rescue
+    rescue => e
       Rails.logger.error "スポット検索でエラー発生: #{e.class} - #{e.message}"
       flash[:alert]  = "正しく検索を行うことができませんでした。再度検索を行ってください"
       redirect_back fallback_location: homes_path and return

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -7,7 +7,8 @@ class SpotsController < ApplicationController
       ActiveRecord::Base.transaction do
         Keyword.find_or_create_keyword_and_fetch_spots(word: word)
       end
-    rescue
+    rescue => e
+      Rails.logger.error "スポット検索でエラー発生: #{e.class} - #{e.message}"
       flash[:alert]  = "正しく検索を行うことができませんでした。再度検索を行ってください"
       redirect_back fallback_location: homes_path and return
     end

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -7,7 +7,7 @@ class SpotsController < ApplicationController
       ActiveRecord::Base.transaction do
         Keyword.find_or_create_keyword_and_fetch_spots(word: word)
       end
-    rescue => e
+    rescue
       Rails.logger.error "スポット検索でエラー発生: #{e.class} - #{e.message}"
       flash[:alert]  = "正しく検索を行うことができませんでした。再度検索を行ってください"
       redirect_back fallback_location: homes_path and return

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -76,7 +76,6 @@ class Spot < ApplicationRecord
       category_id: category_id
     }
     end
-binding.pry
     insert_all!(spots_insert_all_data)
 
     spot_ids = where(unique_number: spots_unique_numbers).ids

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -63,10 +63,6 @@ class Spot < ApplicationRecord
     spots_insert_all_data = spot_details.map do |spot_detail|
       # 開発環境ではcategory_idがnilになることがあったため
       category_id = spot_category_hash[spot_detail["id"]] || OTHER_CATEGORY_ID
-      if category_id.nil?
-        Rails.logger.warn("category_idが見つかりません: #{spot_detail["id"]}")
-        category_id = OTHER_CATEGORY_ID
-      end
       {
       unique_number: spot_detail["id"],
       spot_name: spot_detail.dig("displayName", "text"),

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -61,6 +61,7 @@ class Spot < ApplicationRecord
     spot_category_hash = spot_category.map { |spot| [ spot[:unique_number], spot[:category_id] ] }.to_h
 
     spots_insert_all_data = spot_details.map do |spot_detail|
+      # 開発環境ではcategory_idがnilになることがあったため
       category_id = spot_category_hash[spot_detail["id"]] || OTHER_CATEGORY_ID
       if category_id.nil?
         Rails.logger.warn("category_idが見つかりません: #{spot_detail["id"]}")

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -47,8 +47,8 @@ class Spot < ApplicationRecord
 
     spot_category = grouped.map do |unique_number, records|
       sorted = records.group_by { |record| record[:category_id] }.sort_by { |_, category_id| category_id.size }
-      first_category_id = sorted[0].first
-      second_category_id = sorted[1].first
+      first_category_id = sorted[0]&.first
+      second_category_id = sorted[1]&.first
 
       if first_category_id == OTHER_CATEGORY_ID
         most_category_id = second_category_id


### PR DESCRIPTION
### 概要
APIを用いたスポット検索の結果を'spots'テーブルに保存する際、以下のように記述することで'category_id'がnilの場合でもエラーが起きないように修正しました。

```
      category_id = spot_category_hash[spot_detail["id"]] || OTHER_CATEGORY_ID
      if category_id.nil?
        Rails.logger.warn("category_idが見つかりません: #{spot_detail["id"]}")
        category_id = OTHER_CATEGORY_ID
      end
```
---