### PR TITLE
seed.rbの修正+各モデルのバリデーション修正

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,4 +1,6 @@
 class Category < ApplicationRecord
   has_many :genres
   has_many :spots
+
+  validates :name, uniqueness: true
 end

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -3,6 +3,8 @@ class Genre < ApplicationRecord
   has_many :spots, through: :genre_spots
   belongs_to :category
 
+  validates :name, uniqueness: true
+
   def self.insert_all(spot_types_summary)
     insert_all!(
     spot_types_summary

--- a/app/models/transportation.rb
+++ b/app/models/transportation.rb
@@ -1,4 +1,6 @@
 class Transportation < ApplicationRecord
   has_many :trip_transportations
   has_many :trips, through: :trip_transportations, dependent: :destroy
+
+  validates :name, uniqueness: true
 end

--- a/db/migrate/20250419034128_create_transportations.rb
+++ b/db/migrate/20250419034128_create_transportations.rb
@@ -1,8 +1,7 @@
 class CreateTransportations < ActiveRecord::Migration[8.0]
   def change
     create_table :transportations do |t|
-      t.string :name
-
+      t.string :name, unique: true
       t.timestamps
     end
   end

--- a/db/migrate/20250528004745_create_categories.rb
+++ b/db/migrate/20250528004745_create_categories.rb
@@ -1,7 +1,7 @@
 class CreateCategories < ActiveRecord::Migration[8.0]
   def change
     create_table :categories do |t|
-      t.string :name
+      t.string :name, unique: true
       t.integer :stay_time
       t.timestamps
     end

--- a/db/migrate/20250528051955_create_genres.rb
+++ b/db/migrate/20250528051955_create_genres.rb
@@ -1,7 +1,7 @@
 class CreateGenres < ActiveRecord::Migration[8.0]
   def change
     create_table :genres do |t|
-      t.string :name
+      t.string :name, unique: true
       t.references :category, null: false, foreign_key: { on_update: :cascade }
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -46,15 +46,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_06_060655) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "genre_spots", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint "spot_id", null: false
-    t.bigint "genres_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["genres_id"], name: "index_genre_spots_on_genres_id"
-    t.index ["spot_id"], name: "index_genre_spots_on_spot_id"
-  end
-
   create_table "genres", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.bigint "category_id", null: false
@@ -197,8 +188,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_06_060655) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "genre_spots", "genres", column: "genres_id", on_update: :cascade
-  add_foreign_key "genre_spots", "spots", on_update: :cascade
   add_foreign_key "genres", "categories", on_update: :cascade
   add_foreign_key "keyword_spots", "keywords", on_update: :cascade, on_delete: :cascade
   add_foreign_key "keyword_spots", "spots", on_update: :cascade, on_delete: :cascade

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,17 +10,17 @@
 
 require "csv"
 
-Category.create!(name: "sightseeing", stay_time: 90)
-Category.create!(name: "shopping", stay_time: 60)
-Category.create!(name: "leisure_land", stay_time: 300)
-Category.create!(name: "nature", stay_time: 50)
-Category.create!(name: "restaurant", stay_time: 60)
-Category.create!(name: "other")
+Category.create(name: "sightseeing", stay_time: 90)
+Category.create(name: "shopping", stay_time: 60)
+Category.create(name: "leisure_land", stay_time: 300)
+Category.create(name: "nature", stay_time: 50)
+Category.create(name: "restaurant", stay_time: 60)
+Category.create(name: "other")
 
-Transportation.create!(name: "車")
-Transportation.create!(name: "電車")
-Transportation.create!(name: "自転車")
+Transportation.create(name: "車")
+Transportation.create(name: "電車")
+Transportation.create(name: "自転車")
 
 CSV.foreach("db/seed_files/genres.csv") do |row|
-  Genre.create!(name: row[0], category_id: row[1])
+  Genre.create(name: row[0], category_id: row[1])
 end


### PR DESCRIPTION
### 概要
以下の修正を行いました
- seed.rbの'create!'メソッドをすべて'create'メソッドに変更
- 初期値を導入するカラムに対してDBとモデルの二つに対して重複制約を実施

上記を実行することで'rails db:seed'をどのタイミングで何回実行しても初期値が重複登録されないようになります。

---