### PR TITLE
作成したプランを表示するページの実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,4 +20,5 @@
 @use "spots/index.scss" as spots_index;
 @use "spots/show.scss" as spots_show;
 @use "trip_users/index.scss" as trip_users_index;
+@use "plans/index.scss" as plans_index;
 @use "shared/trip_data.scss" as shared_trip_data;

--- a/app/assets/stylesheets/plans/index.scss
+++ b/app/assets/stylesheets/plans/index.scss
@@ -27,10 +27,12 @@
         justify-content: space-around;
         margin: 0 auto;
         width: 500px;
+        flex-wrap: wrap;
         .spot {
           border: 1px solid black;
           border-radius: 10px;
           width: 150px;
+          
         }
         .image {
           width: 100px;

--- a/app/assets/stylesheets/plans/index.scss
+++ b/app/assets/stylesheets/plans/index.scss
@@ -32,7 +32,6 @@
           border: 1px solid black;
           border-radius: 10px;
           width: 150px;
-          
         }
         .image {
           width: 100px;

--- a/app/assets/stylesheets/plans/index.scss
+++ b/app/assets/stylesheets/plans/index.scss
@@ -1,0 +1,79 @@
+.plans-index {
+  .card-style {
+    margin: 0 auto;
+    margin-top: 100px;
+    margin-bottom: 100px;
+    width: 600px;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    box-shadow: 0 4px 9px rgba(0, 0, 0, 0.1);
+    padding: 10px;
+    .created-plan {
+      margin-top: 50px;
+      text-align: center;
+      font-size: 30px;
+    }
+    .plans-container {
+      p {
+        font-size: 25px;
+        font-weight: bold;
+      } 
+      text-align: center;
+      width: 600px;
+      margin: 0 auto;
+      margin-bottom: 50px;
+      .spots-container {
+        display: flex;
+        justify-content: space-around;
+        margin: 0 auto;
+        width: 500px;
+        .spot {
+          border: 1px solid black;
+          border-radius: 10px;
+          width: 150px;
+        }
+        .image {
+          width: 100px;
+          height: 100px;
+        }
+      }
+    }
+    .guide-book {
+      display: table;
+      width: 550px;
+      margin: 0 auto;
+      margin-bottom: 10px;
+      border: 1px solid black;
+      border-radius: 10px 10px 0 0;
+      overflow: hidden;
+
+      .guide-headline {
+        display: table-row;
+        background-color: #d3d3d3;
+        text-align: center;
+        font-weight: bold;
+      }
+      .guide-row {
+        display: table-row;
+      }
+      .time-cell {
+        padding: 10px;
+        display: table-cell;
+        border-right: 1px solid black;
+        text-align: center;
+        width: 150px;
+        font-size: 20px;
+      }
+      .content-cell {
+        padding: 10px;
+        display: table-cell;
+        text-align: center;
+        width: 400px;
+        font-size: 20px;
+      }
+      .spot_link {
+        color: blue;
+      }
+    }
+  }
+}

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -1,4 +1,9 @@
 class PlansController < ApplicationController
+  def index
+    @trip = Trip.find(params[:trip_id])
+    @plan = Plan.find(params[:plan_id])
+    @spots = @plan.spots.order(order: :asc)
+  end
   def create
     trip = Trip.find(params[:trip_id])
     spot_distance = DistanceMatrix.spot_distance(origins: params[:spot_unique_numbers], destinations: params[:spot_unique_numbers], mode: "driving")
@@ -24,11 +29,12 @@ class PlansController < ApplicationController
     ActiveRecord::Base.transaction do
       orderd_spots = best_route.map { |i| spots_data_sort[i] }
       durations = best_route.each_cons(2).map { |a, b| spot_distance[:duration][a][b] }
-      plan = Plan.create!(trip_id: trip.id)
+      plan_title = Plan.where(trip_id: trip.id).count + 1
+      plan = Plan.create!(trip_id: trip.id, title: plan_title)
       plan_spots_insert_all_data = PlanSpot.create_plan_spots_insert_all_data(orderd_spots: orderd_spots, durations: durations, plan: plan)
       PlanSpot.insert_all!(plan_spots_insert_all_data)
       flash[:notice] = "プランを作成しました"
-      # redirect_to
+      redirect_to trip_plans_path(trip_id: trip.id, plan_id: plan.id)
       return
     end
   end

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -136,4 +136,8 @@ class Spot < ApplicationRecord
     end
     [ total_hours, best_route ]
   end
+
+  def move_duration(plan)
+    self.plan_spots.find_by(plan_id: plan.id).duration
+  end
 end

--- a/app/views/plans/index.html.erb
+++ b/app/views/plans/index.html.erb
@@ -1,0 +1,63 @@
+<div class="plans-index">
+  <div class="card-style">
+    <%= render "shared/trip_data", trip: @trip %>
+    <p class="created-plan"><%= t('.created-plan') %></p>
+    <div class="plans-container">
+      <p>プラン<%= @plan.title %></p>
+      <div class="spots-container">
+        <% @spots.each do |spot| %>
+          <div class="spot">
+            <%= link_to spot.spot_name.truncate(6, omission: "‥"), trip_spot_path(@trip.id, spot.id) %>
+            <%= image_tag spot.image_url, class:"image" %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+    <div class="guide-book">
+      <div class="guide-headline">
+        <div class="time-cell">
+          <%= t('.time')%>
+        </div>
+        <div class="content-cell">
+          <%= t('.content') %>
+        </div>
+      </div>
+      <% current_time = @trip.start_time %>
+      <% @spots.each_with_index do |spot, i| %>
+        <% if i > 0 %>
+          <% move_duration = @spots[i - 1].move_duration(@plan) %>
+          <div class="guide-row">
+            <div class="time-cell">
+              <%= current_time.strftime("%H:%M") %>
+            </div>
+            <div class="content-cell">
+              <%= t('.move-time') %>(<%= move_duration %>分)
+            </div>
+          </div>
+          <% current_time += move_duration.minutes %>
+        <% end %>
+        <div class="guide-row">
+          <div class="time-cell">
+            <%= current_time.strftime("%H:%M") %>
+          </div>
+          <div class="content-cell">
+            <%= link_to trip_spot_path(@trip.id, spot.id), class:"spot_link" do %>
+              <%= spot.spot_name %>(滞在:<%= spot.category.stay_time %>分)
+            <% end %>
+          </div>
+        </div>
+        <% current_time += spot.category.stay_time.minutes %>
+        <% if i == @spots.length - 1 %>
+          <div class="guide-row">
+            <div class="time-cell">
+              <%= current_time.strftime("%H:%M") %>
+            </div>
+            <div class="content-cell">
+              <%= t('.finish') %>
+            </div>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/trip_users/index.html.erb
+++ b/app/views/trip_users/index.html.erb
@@ -1,8 +1,6 @@
 <div class="trip-users-index">
   <div class="card-style">
-    <div class="trip-data-container">
-      <%= render "shared/trip_data", trip: @trip  %>
-    </div>
+    <%= render "shared/trip_data", trip: @trip  %>
     <div class="trip-users-card-style">
       <div class="title">
         <%= t('.title') %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -81,3 +81,12 @@ ja:
       delete: 削除する
       exit: 退会する
       trip_show: しおり詳細ページに戻る
+  plans:
+    index:
+      title: 提案するプラン
+      created-plan: 以下のプランを作成しました🎉🎉
+      guide-book-title: 旅のしおり
+      time: 時間
+      content: 内容
+      move-time: 移動時間
+      finish: 終了

--- a/db/migrate/20250606055106_create_plans.rb
+++ b/db/migrate/20250606055106_create_plans.rb
@@ -2,6 +2,7 @@ class CreatePlans < ActiveRecord::Migration[8.0]
   def change
     create_table :plans do |t|
       t.timestamps
+      t.string :title
       t.references :trip, null: false, foreign_key: { on_update: :cascade, on_delete: :cascade }
     end
   end

--- a/db/migrate/20250606060655_create_plan_spots.rb
+++ b/db/migrate/20250606060655_create_plan_spots.rb
@@ -3,7 +3,7 @@ class CreatePlanSpots < ActiveRecord::Migration[8.0]
     create_table :plan_spots do |t|
       t.timestamps
       t.integer :order
-      t.string :duration
+      t.integer :duration
       t.references :spot, null: false, foreign_key: { on_update: :cascade, on_delete: :cascade }
       t.references :plan, null: false, foreign_key: { on_update: :cascade, on_delete: :cascade }
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -73,7 +73,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_06_060655) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "order"
-    t.string "duration"
+    t.integer "duration"
     t.bigint "spot_id", null: false
     t.bigint "plan_id", null: false
     t.index ["plan_id"], name: "index_plan_spots_on_plan_id"
@@ -83,6 +83,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_06_060655) do
   create_table "plans", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "title"
     t.bigint "trip_id", null: false
     t.index ["trip_id"], name: "index_plans_on_trip_id"
   end


### PR DESCRIPTION
### 概要
作成したプランを表示するページを実装しました
レイアウトは以下になります
<img width="503" alt="スクリーンショット 2025-06-11 17 19 46" src="https://github.com/user-attachments/assets/205cc56d-ef4d-438c-8438-d3563fa24108" />

### 修正内容
1. **プランに含まれるスポットの表示**
- スポットの画像とスポット名を横一列に表示
- スポットが4つ以上ある場合は改行して下に表示する

2. **プランの時間割の表示**
- 'display: table 'を用いたテーブル表示
- 'each_with_index'を用いて以下の処理を実行
    - 最初の処理のみ特別処理
    - 各移動時間と滞在時間を順次加算
    - 最後の処理時に「終了」表示を追加

---