### PR TITLE
trip_usersのログインしているユーザーがリーダーかどうか判別する仕組みを修正

### DIFF
--- a/app/controllers/trip_users_controller.rb
+++ b/app/controllers/trip_users_controller.rb
@@ -1,7 +1,6 @@
 class TripUsersController < ApplicationController
   def index
     @trip = Trip.find(params[:trip_id])
-    @current_user_is_leader = TripUser.current_user_is_leader?(trip: @trip, current_user: current_user)
   end
 
   def change_leader

--- a/app/models/trip_user.rb
+++ b/app/models/trip_user.rb
@@ -11,8 +11,8 @@ class TripUser < ApplicationRecord
     end
   end
 
-  def self.current_user_is_leader?(trip:, current_user:)
-    find_by!(trip_id: trip.id, user_id: current_user.id).is_leader?
+  def current_user_is_leader?(trip:, current_user:)
+    TripUser.find_by!(trip_id: trip.id, user_id: current_user.id).is_leader?
   end
 
   def sort_leader_first
@@ -26,8 +26,8 @@ class TripUser < ApplicationRecord
     self.user_id == current_user.id
   end
 
-  def show_leader_change_link?(current_user:, current_user_is_leader:)
-    self.user_id != current_user.id && current_user_is_leader
+  def show_leader_change_link?(current_user:, trip:)
+    self.user_id != current_user.id && self.current_user_is_leader?(trip: trip, current_user: current_user)
   end
 
   def show_current_user_delete_link?(current_user:)

--- a/app/views/trip_users/index.html.erb
+++ b/app/views/trip_users/index.html.erb
@@ -20,7 +20,7 @@
             </div>
           </div>
           <div class="update-delete-container">
-            <% if trip_user.show_leader_change_link?(current_user: current_user, current_user_is_leader: @current_user_is_leader) %>
+            <% if trip_user.show_leader_change_link?(current_user: current_user, trip: @trip) %>
               <%= link_to change_leader_trip_trip_user_path(trip_id: @trip.id, id: trip_user.id ), data: { confirm: "本当に変更しますか？"} do %>
                 <i class="fa-solid fa-crown member-icon fa-lg"></i>
                 <%= t('.update-leader') %>


### PR DESCRIPTION
### 概要
'trip_users/index'において、ログインしているユーザーがリーダーかどうかを判別する方法最適化しました

1. 'TripUser.rb'にインスタンスメソッド(current_user_is_leader?)を作成
```
  def current_user_is_leader?(trip:, current_user:)
    TripUser.find_by!(trip_id: trip.id, user_id: current_user.id).is_leader?
  end
```

2. インスタンスメソッド'show_leader_change_link?'内で以下のように処理
```
 def show_leader_change_link?(current_user:, trip:)
    self.user_id != current_user.id && self.current_user_is_leader?(trip: trip, current_user: current_user)
  end
```

このようにすることで無駄な処理なくスムーズな判別が可能になります