### PR TITLE
trip_usersの並び順のロジックをリファクタリング

### DIFF
--- a/app/controllers/trip_users_controller.rb
+++ b/app/controllers/trip_users_controller.rb
@@ -1,6 +1,7 @@
 class TripUsersController < ApplicationController
   def index
     @trip = Trip.find(params[:trip_id])
+    @trip_users = @trip.trip_users.order(is_leader: :desc)
   end
 
   def change_leader

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -18,6 +18,7 @@ class TripsController < ApplicationController
 
   def show
     @trip = Trip.find(params[:id])
+    @trip_users = @trip.trip_users.order(is_leader: :desc)
     @spot_suggestions = @trip.spot_suggestions
     spot_votes = @trip.spot_votes.pluck(:spot_suggestion_id)
     ng_spot = spot_votes.group_by { |s| s }.select { |_, value| value.size >= 2 }.keys

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -38,10 +38,7 @@ class Trip < ApplicationRecord
     (self.spot_vote_limit - Date.today).to_i
   end
 
-  def sort_leader_first
-    trip_users = self.trip_users.to_a
-    leader = trip_users.find { |trip_user| trip_user.is_leader }
-    trip_users.delete(leader)
-    trip_users.unshift(leader)
+  def trip_users_sort_by_leader
+    self.trip_users.order(is_leader: :desc)
   end
 end

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -37,7 +37,7 @@
                 <div class="member">
                   <%= t('.member')%>
                 </div>
-                <% t.sort_leader_first.each do |trip_user| %>
+                <% t.trip_users_sort_by_leader.each do |trip_user| %>
                   <div class="member-list">
                     <% if trip_user.is_leader == true %>
                       <i class="fa-solid fa-crown crown-icon "></i>

--- a/app/views/trip_users/index.html.erb
+++ b/app/views/trip_users/index.html.erb
@@ -5,7 +5,7 @@
       <div class="title">
         <%= t('.title') %>
       </div>
-      <% @trip.sort_leader_first.each do |trip_user| %>
+      <% @trip_users.each do |trip_user| %>
         <div class="container">
           <div class="icon-name-container">
             <% if trip_user.is_leader %>

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -13,7 +13,7 @@
         <div class="member-title">
           <%= t('.member') %>
         </div>
-        <% @trip.sort_leader_first.each do |trip_user| %>
+        <% @trip_users.each do |trip_user| %>
           <div class="member-list">
             <% if trip_user.is_leader == true %>
               <i class="fa-solid fa-crown crown-icon "></i>


### PR DESCRIPTION
### 概要
trip_usersを表示する際にリーダーが最初に来るような並び順に変更するロジックを以下のように変更しました

- 'trip_users'と'trip'について
1. 各コントローラに以下のインスタンス変数を作成する(orderを用いることで'true'が先頭に来る)
```
 @trip_users = @trip.trip_users.order(is_leader: :desc)
```

2. ビューで@trip_usersを用いた繰り返し処理を行う

- 'homes'について
1. 'trip.rb'にインスタンスメソッド'trip_users_sort_by_leader'を作成

2. ビューで呼び出す

---