### PR TITLE
プラン候補のレイアウトを変更

### DIFF
--- a/app/assets/stylesheets/plans/index.scss
+++ b/app/assets/stylesheets/plans/index.scss
@@ -3,29 +3,39 @@
     margin: 0 auto;
     margin-top: 100px;
     margin-bottom: 100px;
-    width: 600px;
+    width: 1500px;
     border: 1px solid #ddd;
     border-radius: 8px;
     box-shadow: 0 4px 9px rgba(0, 0, 0, 0.1);
-    padding: 10px;
+    padding-bottom: 10px;
+    text-align: center;
     .created-plan {
-      margin-top: 50px;
       text-align: center;
       font-size: 30px;
     }
-    .decided {
-      width: 200px;
+    .plans-container {
+      display: flex;
+      width: 1300px;
+      flex-wrap: wrap;
       margin: 0 auto;
-      text-align: center;
-      margin-top: 50px;
-      margin-bottom: 50px;
-    }
-    .decided-button {
-      font-size: 20px;
-      background-color: #007bff;
-      color: white;
-      border: 1px solid #007bff;
-      border-radius: 4px;
+      .plan-container {
+        border:1px solid black;
+        border-radius: 5px;
+      }
+      .decided {
+        width: 200px;
+        margin: 0 auto;
+        text-align: center;
+        margin-top: 50px;
+        margin-bottom: 50px;
+      }
+      .decided-button {
+        font-size: 20px;
+        background-color: #007bff;
+        color: white;
+        border: 1px solid #007bff;
+        border-radius: 4px;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/shared/plan.scss
+++ b/app/assets/stylesheets/shared/plan.scss
@@ -1,7 +1,8 @@
-.plans-container {
+.plan-container {
   p {
     font-size: 25px;
     font-weight: bold;
+    padding-top: 10px;
   } 
   text-align: center;
   width: 600px;
@@ -13,6 +14,7 @@
     margin: 0 auto;
     width: 500px;
     flex-wrap: wrap;
+    margin-bottom: 50px;
     .spot {
       border: 1px solid black;
       border-radius: 10px;

--- a/app/assets/stylesheets/shared/trip_data.scss
+++ b/app/assets/stylesheets/shared/trip_data.scss
@@ -1,27 +1,31 @@
 .title {
- text-align: center;
- gap: 20px;
- font-size: 30px;
- margin-top: 30px;
- margin-bottom: 30px;
+  text-align: center;
+  gap: 20px;
+  font-size: 30px;
+  margin-top: 30px;
+  margin-bottom: 30px;
 }
-.trip-detail {
- margin-left: 50px;
- margin-bottom: 20px;
- font-size: 20px;
- .icon-label {
-   display: flex;
-   align-items: center;
-   gap: 10px;
- }
- .trip-info {
-   display: flex;
-   align-items: center;
-   padding: 10px;
-   width: 300px;
-   height: 40px;
-   border: 1px solid #ddd;
-   border-radius: 8px;
-   box-shadow: 0 4px 9px rgba(0, 0, 0, 0.1);
- }
+.trip-detail-container {
+  margin-bottom: 50px;
+  .trip-detail {
+    width: 300px;
+    margin-bottom: 20px;
+    font-size: 20px;
+    margin: 0 auto;
+    .icon-label {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+    .trip-info {
+      display: flex;
+      align-items: center;
+      padding: 10px;
+      width: 300px;
+      height: 40px;
+      border: 1px solid #ddd;
+      border-radius: 8px;
+      box-shadow: 0 4px 9px rgba(0, 0, 0, 0.1);
+    }
+  }
 }

--- a/app/views/plans/index.html.erb
+++ b/app/views/plans/index.html.erb
@@ -2,6 +2,10 @@
   <div class="card-style">
     <%= render "shared/trip_data", trip: @trip %>
     <p class="created-plan"><%= t('.created-plan') %></p>
-    <%= render "shared/plan", trip: @trip, plans: @plans %>
+    <div class="plans-container">
+      <% @plans.each do |plan| %>
+        <%= render partial: "shared/plan", :as => "plan", locals: { trip: @trip, plan: plan} %>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/shared/_plan.html.erb
+++ b/app/views/shared/_plan.html.erb
@@ -1,14 +1,9 @@
-<% plans.each do |plan|%>
-  <div class="plans-container">
-    <p>プラン<%= plan.title %></p>
-    <div class="spots-container">
-      <% plan.spots.order(order: :asc).each do |spot| %>
-        <div class="spot">
-          <%= link_to spot.spot_name.truncate(6, omission: "‥"), trip_spot_path(trip.id, spot.id) %>
-          <%= image_tag spot.image_url, class:"image" %>
-        </div>
-      <% end %>
-    </div>
+<div class="plan-container">
+  <p>プラン<%= plan.title %></p>
+  <div class="spots-container">
+    <% plan.spots.each do |spot| %>
+      <%= render partial: "shared/plan_spots", locals: { trip: trip, spot: spot } %>
+    <% end %>
   </div>
   <div class="guide-book">
     <div class="guide-headline">
@@ -33,16 +28,7 @@
         </div>
         <% current_time += move_duration.minutes %>
       <% end %>
-      <div class="guide-row">
-        <div class="time-cell">
-          <%= current_time.strftime("%H:%M") %>
-        </div>
-        <div class="content-cell">
-          <%= link_to trip_spot_path(trip.id, spot.id), class:"spot_link" do %>
-            <%= spot.spot_name %>(滞在:<%= spot.category.stay_time %>分)
-          <% end %>
-        </div>
-      </div>
+      <%= render partial: "shared/schedule", locals: { spot: spot, i: i, current_time: current_time, trip: trip, plan_spots: plan.spots, plan: plan} %>
       <% current_time += spot.category.stay_time.minutes %>
       <% if i == plan.spots.length - 1 %>
         <div class="guide-row">
@@ -56,4 +42,4 @@
       <% end %>
     <% end %>
   </div>
-<% end %>
+</div>

--- a/app/views/shared/_plan.html.erb
+++ b/app/views/shared/_plan.html.erb
@@ -28,7 +28,16 @@
         </div>
         <% current_time += move_duration.minutes %>
       <% end %>
-      <%= render partial: "shared/schedule", locals: { spot: spot, i: i, current_time: current_time, trip: trip, plan_spots: plan.spots, plan: plan} %>
+      <div class="guide-row">
+        <div class="time-cell">
+          <%= current_time.strftime("%H:%M") %>
+        </div>
+        <div class="content-cell">
+          <%= link_to trip_spot_path(trip.id, spot.id), class:"spot_link" do %>
+            <%= spot.spot_name %>(滞在:<%= spot.category.stay_time %>分)
+          <% end %>
+        </div>
+      </div>
       <% current_time += spot.category.stay_time.minutes %>
       <% if i == plan.spots.length - 1 %>
         <div class="guide-row">

--- a/app/views/shared/_plan_spots.erb
+++ b/app/views/shared/_plan_spots.erb
@@ -1,0 +1,4 @@
+<div class="spot">
+  <%= link_to spot.spot_name.truncate(6, omission: "‥"), trip_spot_path(trip.id, spot.id) %>
+  <%= image_tag spot.image_url, class:"image" %>
+</div>

--- a/app/views/shared/_schedule.html.erb
+++ b/app/views/shared/_schedule.html.erb
@@ -1,0 +1,10 @@
+<div class="guide-row">
+  <div class="time-cell">
+    <%= current_time.strftime("%H:%M") %>
+  </div>
+  <div class="content-cell">
+    <%= link_to trip_spot_path(trip.id, spot.id), class:"spot_link" do %>
+      <%= spot.spot_name %>(滞在:<%= spot.category.stay_time %>分)
+    <% end %>
+  </div>
+</div>

--- a/app/views/shared/_trip_data.html.erb
+++ b/app/views/shared/_trip_data.html.erb
@@ -3,21 +3,23 @@
   <%= trip.title %>
   <i class="fa-solid fa-book-open"></i>
 </div>
-<div class="trip-detail">
-  <div class="icon-label">
-    <i class="fa-solid fa-calendar-days"></i>
-    <%= Trip.human_attribute_name(:date) %>
+<div class="trip-detail-container">
+  <div class="trip-detail">
+    <div class="icon-label">
+      <i class="fa-solid fa-calendar-days"></i>
+      <%= Trip.human_attribute_name(:date) %>
+    </div>
+    <div class="trip-info">
+      <%= trip.date %>
+    </div>
   </div>
-  <div class="trip-info">
-    <%= trip.date %>
-  </div>
-</div>
-<div class="trip-detail">
-  <div class="icon-label">
-    <i class="fa-solid fa-plane"></i>
-    <%= Trip.human_attribute_name(:distination) %>
-  </div>
-  <div class="trip-info">
-    <%= trip.distination %>
+  <div class="trip-detail">
+    <div class="icon-label">
+      <i class="fa-solid fa-plane"></i>
+      <%= Trip.human_attribute_name(:distination) %>
+    </div>
+    <div class="trip-info">
+      <%= trip.distination %>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
### 概要
作成したプランの表示レイアウトを以下のように変更しました。
またプラン表示のコードをリファクタリングしました

<img width="848" alt="スクリーンショット 2025-06-15 10 18 43" src="https://github.com/user-attachments/assets/36cfabb1-4253-4ed7-b31d-c336b6410505" />

### 修正内容

1. プラン表示のリファクタリング
 - 'shared'に以下のファイルを作成し、'plan.index'から呼び出す形に変更しました
    - '_plan.html'
    - '_plan_spots.html'

2. 'plan_index'において、'<% plan.spots.each_with_index do |spot, i| %>'この処理をcollectionを用いた部分テンプレートの繰り返し呼び出しにしなかった理由
  - 繰り返し処理内で変数'current_time'を更新し、次の繰り返し処理内に引き継ぐと言う形で処理を進めたいが、部分テンプレートにしてしまうと処理間で引き継ぐことができないため

3. 'plan_indexにおいて_plan_spots'の繰り返し呼び出し処理に'collection'を用いない理由
- 繰り返し処理で表示する内容をすべて一つのブロック要素に含めたいため