### PR TITLE
幹事がプランを決定する仕組みを作成

### DIFF
--- a/app/assets/stylesheets/plans/index.scss
+++ b/app/assets/stylesheets/plans/index.scss
@@ -20,34 +20,31 @@
       scroll-snap-type: x mandatory;
       width: 580px;
       margin: 0 auto;
-      .plan-container {
-        position: relative;
-        border:1px solid black;
-        border-radius: 5px;
-        scroll-snap-align: start;
-        width: 550px;
-        padding: 10px;
-        .dot-icon {
-          width: 100%;
-          margin: 0 auto;
-          position: absolute;
-          bottom: 20px;
-        }
-      }
-      .decided {
-        width: 200px;
-        margin: 0 auto;
-        text-align: center;
-        margin-top: 50px;
-        margin-bottom: 50px;
-      }
-      .decided-button {
-        font-size: 20px;
-        background-color: #007bff;
-        color: white;
-        border: 1px solid #007bff;
-        border-radius: 4px;
-      }
+    }
+    .decided-form {
+      width: 400px;
+      margin: 0 auto;
+      margin-top: 50px;
+      margin-bottom: 50px;
+    }
+    .decided-button {
+      padding: 10px;
+      font-size: 25px;
+      font-weight: bold;
+      color: white;
+      background-color: #007bff;
+      border: 1px solid #007bff;
+      border-radius: 4px;
+      cursor: pointer;
+    }
+    .wait {
+      font-size: 40px;
+      margin-bottom: 50px;
+      font-weight: bold;
+    }
+    .wait-detail {
+      font-size: 30px;
+      margin-bottom: 100px;
     }
   }
 }

--- a/app/assets/stylesheets/shared/plan.scss
+++ b/app/assets/stylesheets/shared/plan.scss
@@ -4,10 +4,31 @@
     font-weight: bold;
     padding-top: 10px;
   } 
+  position: relative;
+  border:1px solid black;
+  border-radius: 5px;
+  scroll-snap-align: start;
+  width: 550px;
+  padding: 10px;
   text-align: center;
-  width: 600px;
-  margin: 0 auto;
-  margin-bottom: 50px;
+    .selected {
+    display: none;
+  }
+  &.is-selected {
+    .selected {
+      display: block;
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100px;
+      text-align: center;
+      background-color: #4CAF50;
+      color: white;
+      padding: 3px 8px;
+      font-size: 30px;
+      border-radius: 4px;
+    }
+  }
   .spots-container {
     display: flex;
     justify-content: space-around;
@@ -25,40 +46,61 @@
       height: 100px;
     }
   }
-}
-.guide-book {
-  display: table;
-  width: 550px;
-  margin: 0 auto;
-  margin-bottom: 50px;
-  border: 1px solid black;
-  border-radius: 10px 10px 0 0;
-  overflow: hidden;
-  .guide-headline {
-    display: table-row;
-    background-color: #d3d3d3;
-    text-align: center;
-    font-weight: bold;
+  .guide-book {
+    display: table;
+    width: 550px;
+    margin: 0 auto;
+    margin-bottom: 150px;
+    border: 1px solid black;
+    border-radius: 10px 10px 0 0;
+    overflow: hidden;
+    .guide-headline {
+      display: table-row;
+      background-color: #d3d3d3;
+      text-align: center;
+      font-weight: bold;
+    }
+    .guide-row {
+      display: table-row;
+    }
+    .time-cell {
+      padding: 10px;
+      display: table-cell;
+      border-right: 1px solid black;
+      text-align: center;
+      width: 150px;
+      font-size: 20px;
+    }
+    .content-cell {
+      padding: 10px;
+      display: table-cell;
+      text-align: center;
+      width: 400px;
+      font-size: 20px;
+    }
+    .spot_link {
+      color: blue;
+    }
   }
-  .guide-row {
-    display: table-row;
+  .dot-icon {
+    width: 100%;
+    position: absolute;
+    bottom: 20px;
   }
-  .time-cell {
-    padding: 10px;
-    display: table-cell;
-    border-right: 1px solid black;
-    text-align: center;
-    width: 150px;
-    font-size: 20px;
+  .select-form {
+    position: absolute;
+    top: 0px;
+    left: 0px;
   }
-  .content-cell {
-    padding: 10px;
-    display: table-cell;
-    text-align: center;
-    width: 400px;
-    font-size: 20px;
+  &.is-selected .select-form {
+    display: none;
   }
-  .spot_link {
-    color: blue;
+  .selected-button {
+    font-size: 25px;
+    color: white;
+    background-color:  blue;
+    border: 1px solid blue;
+    border-radius: 4px;
+    cursor: pointer;
   }
 }

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -2,6 +2,10 @@ class PlansController < ApplicationController
   def index
     @trip = Trip.find(params[:trip_id])
     @plans = @trip.plans
+    @trip_users = @trip.trip_users
+    if @trip.decided_plan_id.present?
+      redirect_to trip_path(@trip)
+    end
   end
   def create
     trip = Trip.find(params[:trip_id])
@@ -29,7 +33,6 @@ class PlansController < ApplicationController
     begin
       ActiveRecord::Base.transaction do
         routes.each_with_index do |route, index|
-          binding.pry
           ordered_spots = route.map { |i| spots_data_sort[i] }
           durations = route.each_cons(2).map { |a, b| spot_distance[:duration][a][b] }
           plan = Plan.create!(trip_id: trip.id, title: index + 1)

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -18,7 +18,7 @@ class TripsController < ApplicationController
 
   def decided_plan
     trip = Trip.find(params[:id])
-    if trip.update!(decided_plan_id: params[:plan_id])
+    if trip.update!(decided_plan_id: params[:selected_plan_id])
       flash[:notice] = "プランを決定しました"
       redirect_to trip_path(trip)
     else

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -5,4 +5,5 @@ import "preview_image"
 import Rails from "@rails/ujs"
 import "flatpickr/calendarpickr"
 import "flatpickr/timepickr"
+import "selected_plan"
 Rails.start()

--- a/app/javascript/selected_plan.js
+++ b/app/javascript/selected_plan.js
@@ -1,0 +1,16 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const plan_containers = document.querySelectorAll(".plan-container");
+  plan_containers.forEach(plan => {
+    const button = plan.querySelector(".selected-button");
+    button.addEventListener("click", () => {
+    plan_containers.forEach(plan => plan.classList.remove("is-selected"));
+    plan.classList.add("is-selected");
+    const selected_plan_id = plan.dataset.planId
+
+    const hiddenField = document.getElementById("selected_plan_id_field");
+    if (hiddenField) {
+      hiddenField.value = selected_plan_id;
+    }
+    });
+  });
+});

--- a/app/models/trip_user.rb
+++ b/app/models/trip_user.rb
@@ -11,8 +11,8 @@ class TripUser < ApplicationRecord
     end
   end
 
-  def current_user_is_leader?(trip:, current_user:)
-    TripUser.find_by!(trip_id: trip.id, user_id: current_user.id).is_leader
+  def self.current_user_is_leader?(trip:, current_user:)
+    find_by!(trip_id: trip.id, user_id: current_user.id).is_leader
   end
 
   def sort_leader_first
@@ -27,7 +27,7 @@ class TripUser < ApplicationRecord
   end
 
   def show_leader_change_link?(current_user:, trip:)
-    self.user_id != current_user.id && self.current_user_is_leader?(trip: trip, current_user: current_user)
+    self.user_id != current_user.id && TripUser.current_user_is_leader?(trip: trip, current_user: current_user)
   end
 
   def show_current_user_delete_link?(current_user:)

--- a/app/views/plans/index.html.erb
+++ b/app/views/plans/index.html.erb
@@ -1,11 +1,27 @@
 <div class="plans-index">
   <div class="card-style">
     <%= render "shared/trip_data", trip: @trip %>
-    <p class="created-plan"><%= t('.created-plan') %></p>
-    <div class="plans-container">
-      <% @plans.each_with_index do |plan, plan_index| %>
-        <%= render partial: "shared/plan", :as => "plan", locals: { trip: @trip, plan: plan, plan_index: plan_index, size: @plans.size} %>
+    <% if @trip_users.current_user_is_leader?(trip: @trip, current_user: current_user) %>
+      <p class="created-plan"><%= t('.created-plan') %></p>
+      <%= form_with url: trip_decided_plan_path(@trip.id), method: :post do |f| %>
+        <div class="plans-container">
+          <% @plans.each_with_index do |plan, plan_index| %>
+            <%= render partial: "shared/plan", :as => "plan", locals: { trip: @trip, plan: plan, plan_index: plan_index, size: @plans.size, plan_create: true} %>
+          <% end %>
+        </div>
+        <%= hidden_field_tag :selected_plan_id, nil, id: "selected_plan_id_field" %>
+        <div class="decided-form">
+          <%= f.submit t(".decided-button"), class:"decided-button" %>
+        </div>
       <% end %>
-    </div>
+    <% else %>
+      <div class="wait">
+        <%= t('.wait')%>
+      </div>
+      <div class="wait-detail">
+        <p><%= t('.wait-detail')%></p>
+        <p><%= t('.wait-detail2')%></p>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/shared/_plan.html.erb
+++ b/app/views/shared/_plan.html.erb
@@ -1,4 +1,7 @@
-<div class="plan-container">
+<div class="plan-container" data-plan-id="<%= plan.id %>">
+  <div class="selected">
+    <%= t('plans.index.selected')%>
+  </div>
   <p>プラン<%= plan.title %></p>
   <div class="spots-container">
     <% plan.spots.each do |spot| %>
@@ -51,13 +54,18 @@
       <% end %>
     <% end %>
   </div>
-  <div class="dot-icon">
-    <% size.times.each_with_index do |icon, icon_index| %>
-      <% if plan_index == icon_index %>
-        <i class="fa-solid fa-circle"></i>
-      <% else %>
-        <i class="fa-regular fa-circle"></i>
+  <% if plan_create %>
+    <div class="dot-icon">
+      <% size.times.each_with_index do |icon, icon_index| %>
+        <% if plan_index == icon_index %>
+          <i class="fa-solid fa-circle"></i>
+        <% else %>
+          <i class="fa-regular fa-circle"></i>
+        <% end %>
       <% end %>
-    <% end %>
-  </div>
+    </div>
+    <div class="select-form">
+      <button type ="button" class="selected-button"><%= t('plans.index.selected-plan') %></button>
+    </div>
+  <% end %>
 </div>

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -2,7 +2,7 @@
   <div class="card-style">
     <%= render "shared/trip_data", trip: @trip %>
     <% if @trip.decided_plan_id.present? %>
-      <%= render "shared/plan", trip: @trip, spots: @spots, plan: @plan %>
+      <%= render "shared/plan", trip: @trip, spots: @spots, plan: @plan, plan_create: false %>
     <% else%>
       <turbo-frame id="phase">
         <% if @trip.within_spot_vote_limit_date? %>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -10,3 +10,4 @@ pin "@rails/ujs", to: "@rails--ujs.js" # @7.1.3
 pin "flatpickr" # @4.6.13
 pin "flatpickr/calendarpickr", to: "flatpickr/calendarpickr.js"
 pin "flatpickr/timepickr", to: "flatpickr/timepickr.js"
+pin "selected_plan", to: "selected_plan.js"

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -91,3 +91,9 @@ ja:
       content: 内容
       move-time: 移動時間
       finish: 終了
+      selected: 選択中
+      selected-plan: 選択する
+      decided-button: 決定する
+      wait: 現在プランの作成中!
+      wait-detail: 幹事がプランを選択しております
+      wait-detail2: しばらくお待ちください🙇‍♂️

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
       end
     end
   end
-  post "trip/:id/:plan_id", to: "trips#decided_plan", as: "trip_decided_plan"
+  post "trip/:id/", to: "trips#decided_plan", as: "trip_decided_plan"
 
   root "homes#index"
 


### PR DESCRIPTION
### 概要
複数提案されたプランの中から幹事が一つに決定する仕組みを作成しました
選択されているプランには左上に「選択中」と表示されるようにしております
<img width="427" alt="スクリーンショット 2025-06-16 11 58 18" src="https://github.com/user-attachments/assets/b7d185fe-2c2a-44d9-8ff4-505f0df70fe3" />

<img width="422" alt="スクリーンショット 2025-06-16 11 58 13" src="https://github.com/user-attachments/assets/0e6b59d1-0f16-42e0-a3b3-9f535659e66d" />

### 修正内容
1. JSを用いて各プランにおける選択ボタンをクリックすると「選択中」という文字が表示される仕組みを実装
JSの仕組み
- 'plan_containers'に全ての'plan_container'要素を格納し、それをforEachを用いてひとつずつ以下の処理を行う
-  'selected_button'クラスが付与された'button'がクリックされたら'forEachを用いて全てのplan_container'から'is_selected'クラスを外す
-  現在対象としている'plan_container'に'is_selected'クラスを追加する
-  選択されたプランのplan.idを'selected_plan_id'に格納
- 'hiden_fieldに'selected_plan_id'を追加'

2. ログインしているユーザーが幹事でない場合は以下のページを表示
<img width="500" alt="スクリーンショット 2025-06-16 12 15 20" src="https://github.com/user-attachments/assets/ac2d6c50-33c8-4482-96b0-9b638d3776de" />

- trip.decided_plan_id.present?がtrueになったらtrip_pathに遷移するようにしています
```
  def index
    @trip = Trip.find(params[:trip_id])
    @plans = @trip.plans
    @trip_users = @trip.trip_users
    if @trip.decided_plan_id.present?
      redirect_to trip_path(@trip)
    end
  end
```
3. 決定ボタンをクリックしたらtrip.decided_plan_idを作成しtrip_pathへ遷移
- tripsコントローラのdecided_planで以下の処理を実行
```
  def decided_plan
    trip = Trip.find(params[:id])
    if trip.update!(decided_plan_id: params[:selected_plan_id])
      flash[:notice] = "プランを決定しました"
      redirect_to trip_path(trip)
    else
      flash[:alert] = "プランを選択することができませんでした。別のプランをお試しください"
      redirect_back fallback_location: homes_path
    end
  end
```
4. trip_showのレイアウトは以下になります
<img width="511" alt="スクリーンショット 2025-06-16 12 24 31" src="https://github.com/user-attachments/assets/01ecf760-9bd3-4f79-9990-81195099650d" />
