### PR TITLE
selected_plan.jsの"button.addEventListener"が常に作動していたため条件分岐を作成

### DIFF
--- a/app/assets/stylesheets/shared/plan.scss
+++ b/app/assets/stylesheets/shared/plan.scss
@@ -1,4 +1,5 @@
 .plan-container {
+  margin: 0 auto;
   p {
     font-size: 25px;
     font-weight: bold;

--- a/app/javascript/selected_plan.js
+++ b/app/javascript/selected_plan.js
@@ -1,16 +1,18 @@
-document.addEventListener("DOMContentLoaded", () => {
+document.addEventListener("turbo:load", () => {
   const plan_containers = document.querySelectorAll(".plan-container");
   plan_containers.forEach(plan => {
     const button = plan.querySelector(".selected-button");
-    button.addEventListener("click", () => {
-    plan_containers.forEach(plan => plan.classList.remove("is-selected"));
-    plan.classList.add("is-selected");
-    const selected_plan_id = plan.dataset.planId
+    if (button) {
+      button.addEventListener("click", () => {
+      plan_containers.forEach(plan => plan.classList.remove("is-selected"));
+      plan.classList.add("is-selected");
+      const selected_plan_id = plan.dataset.planId
 
-    const hiddenField = document.getElementById("selected_plan_id_field");
-    if (hiddenField) {
-      hiddenField.value = selected_plan_id;
+      const hiddenField = document.getElementById("selected_plan_id_field");
+      if (hiddenField) {
+        hiddenField.value = selected_plan_id;
+      }
+      });
     }
-    });
   });
 });

--- a/db/migrate/20250612080343_add_decided_plan_id_to_trips.rb
+++ b/db/migrate/20250612080343_add_decided_plan_id_to_trips.rb
@@ -1,6 +1,6 @@
 class AddDecidedPlanIdToTrips < ActiveRecord::Migration[8.0]
   def change
     add_column :trips, :decided_plan_id, :bigint
-    add_foreign_key :trips, :plans, column: :decided_plan_id, on_update: :cascade, on_delete: :cascade
+    add_foreign_key :trips, :plans, column: :decided_plan_id, on_update: :cascade
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -212,6 +212,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_12_080343) do
   add_foreign_key "trip_transportations", "trips", on_update: :cascade, on_delete: :cascade
   add_foreign_key "trip_users", "trips", on_update: :cascade, on_delete: :cascade
   add_foreign_key "trip_users", "users", on_update: :cascade
-  add_foreign_key "trips", "plans", column: "decided_plan_id", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "trips", "plans", column: "decided_plan_id", on_update: :cascade
   add_foreign_key "trips", "users", column: "created_user_id", on_update: :cascade, on_delete: :cascade
 end


### PR DESCRIPTION
### 概要
全ページで'selected_plan.js'の'button.addEventListener'が作動していたため、以下のように条件分岐を設けました
```
if (button) {
      button.addEventListener("click", () => {
      plan_containers.forEach(plan => plan.classList.remove("is-selected"));
      plan.classList.add("is-selected");
      const selected_plan_id = plan.dataset.planId
```