### PR TITLE
tripsコントローラのインスタンス変数を整理

### DIFF
--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -36,29 +36,23 @@ class TripsController < ApplicationController
   def show
     @trip = Trip.find(params[:id])
     @trip_users = @trip.trip_users.order(is_leader: :desc)
-    @spot_suggestions = @trip.spot_suggestions
     spot_votes = @trip.spot_votes.pluck(:spot_suggestion_id)
     ng_spot = spot_votes.group_by { |s| s }.select { |_, value| value.size >= 2 }.keys
-    @voted_result = @spot_suggestions.reject { |spot| ng_spot.include?(spot.id) }
+    @voted_result = @trip.spot_suggestions.reject { |spot| ng_spot.include?(spot.id) }
     @plan = Plan.find_by(id: @trip.decided_plan_id)
-    if @plan.present?
-      @spots = @plan.spots
-    end
   end
 
   def suggestion
-    @trip = Trip.find(params[:id])
-    @spot_suggestions = @trip.spot_suggestions
-    render partial: "trips/suggestion", locals: { trip: @trip, spot_suggestions: @spot_suggestions }
+    trip = Trip.find(params[:id])
+    render partial: "trips/suggestion", locals: { trip: trip, spot_suggestions: trip.spot_suggestions }
   end
 
   def vote
-    @trip = Trip.find(params[:id])
-    @spot_suggestions = @trip.spot_suggestions
-    voted_spot_suggestion_ids = SpotVote.where(trip_id: @trip, user_id: current_user.id).pluck(:spot_suggestion_id)
-    @voted_spot_suggestions = @spot_suggestions.select { |s| voted_spot_suggestion_ids.include?(s.id) }
-    @not_voted_spot_suggestions = @spot_suggestions.reject { |s| voted_spot_suggestion_ids.include?(s.id) }
-    render partial: "trips/vote", locals: { trip: @trip, spot_suggestions: @spot_suggestions, voted_spot_suggestions: @voted_spot_suggestions, not_voted_spot_suggestions: @not_voted_spot_suggestions }
+    trip = Trip.find(params[:id])
+    voted_spot_suggestion_ids = SpotVote.where(trip_id: trip.id, user_id: current_user.id).pluck(:spot_suggestion_id)
+    voted_spot_suggestions = trip.spot_suggestions.select { |s| voted_spot_suggestion_ids.include?(s.id) }
+    not_voted_spot_suggestions = trip.spot_suggestions.reject { |s| voted_spot_suggestion_ids.include?(s.id) }
+    render partial: "trips/vote", locals: { trip: trip, spot_suggestions: trip.spot_suggestions, voted_spot_suggestions: voted_spot_suggestions, not_voted_spot_suggestions: not_voted_spot_suggestions }
   end
 
   private

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -2,11 +2,11 @@
   <div class="card-style">
     <%= render "shared/trip_data", trip: @trip %>
     <% if @trip.decided_plan_id.present? %>
-      <%= render "shared/plan", trip: @trip, spots: @spots, plan: @plan, plan_create: false %>
+      <%= render "shared/plan", trip: @trip, spots: @plan.spots, plan: @plan, plan_create: false %>
     <% else%>
       <turbo-frame id="phase">
         <% if @trip.within_spot_vote_limit_date? %>
-          <%= render partial: "suggestion", locals: { trip: @trip, spot_suggestions: @spot_suggestions, show_delete_link: true } %>
+          <%= render partial: "suggestion", locals: { trip: @trip, spot_suggestions: @trip.spot_suggestions, show_delete_link: true } %>
         <% else %>
           <%= render partial: "vote_result", locals: { trip: @trip, voted_result: @voted_result } %>
         <% end %>


### PR DESCRIPTION
### 概要
'@trip.spot_suggestions'のように元のオブジェクトから簡単にアクセスできるデータについては、新たに変数定義をせず直接呼び出す形に変更しました。

またインスタンス変数にする必要がない箇所が複数箇所あったため、ローカル変数に変更しました