### PR TITLE
プラン作成のロジックをリファクタリング

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -21,10 +21,10 @@ class PlansController < ApplicationController
     travel_max_time = (trip.finish_time - trip.start_time)/60
 
     spots_unique_numbers = params[:spot_unique_numbers]
-    spots_data_sort = Spot.spots_data_sort(spots_unique_numbers)
+    spots_in_vote_order = Spot.spots_in_vote_order(spots_unique_numbers)
 
-    category_ids = spots_data_sort.map(&:category_id)
-    category_stay_time_sort = Category.category_stay_time_sort(spots_data_sort: spots_data_sort, category_ids: category_ids)
+    category_ids = spots_in_vote_order.map(&:category_id)
+    category_stay_time_sort = Category.category_stay_time_sort(category_ids)
 
     spots_combination = (0..number_of_spots-1).to_a
     # 各スポットの組み合わせパターンを検討し、制限時間内に収まる最短ルートを取得
@@ -35,13 +35,7 @@ class PlansController < ApplicationController
     end
     begin
       ActiveRecord::Base.transaction do
-        routes.each_with_index do |route, index|
-          ordered_spots = route.map { |i| spots_data_sort[i] }
-          durations = route.each_cons(2).map { |a, b| spot_distance[:duration][a][b] }
-          plan = Plan.create!(trip_id: trip.id, title: index + 1)
-          plan_spots_insert_all_data = PlanSpot.create_plan_spots_insert_all_data(ordered_spots: ordered_spots, durations: durations, plan: plan)
-          PlanSpot.insert_all!(plan_spots_insert_all_data)
-        end
+        PlanSpot.plan_spots_create(routes: routes, spots_in_vote_order: spots_in_vote_order, spot_distance: spot_distance, trip: trip)
         flash[:notice] = "プランを作成しました"
         redirect_to trip_plans_path(trip_id: trip.id)
       end

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -35,7 +35,10 @@ class PlansController < ApplicationController
     end
     begin
       ActiveRecord::Base.transaction do
-        PlanSpot.plan_spots_create(routes: routes, spots_in_vote_order: spots_in_vote_order, spot_distance: spot_distance, trip: trip)
+        routes.each_with_index do |route, index|
+          plan = Plan.create!(trip_id: trip.id, title: index + 1)
+          PlanSpot.plan_spots_create!(route: route, spots_in_vote_order: spots_in_vote_order, spot_distance: spot_distance, plan: plan)
+        end
         flash[:notice] = "プランを作成しました"
         redirect_to trip_plans_path(trip_id: trip.id)
       end

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -18,7 +18,7 @@ class PlansController < ApplicationController
 
     total_hours = Float::INFINITY
 
-    travel_max_time = (trip.finish_time - trip.start_time)/60
+    travel_max_time = (trip.finish_time - trip.start_time)/Plan::SIXTY_MINUTES
 
     spots_unique_numbers = params[:spot_unique_numbers]
     spots_in_vote_order = Spot.spots_in_vote_order(spots_unique_numbers)

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -4,7 +4,7 @@ class Category < ApplicationRecord
 
   validates :name, uniqueness: true
 
-  def self.category_stay_time_sort(category_ids)
+  def self.category_stay_time_in_vote_order(category_ids)
     category_data = Category.where(id: category_ids).index_by(&:id)
     category_ids.map { |s| category_data[s] }.pluck(:id, :stay_time).to_h
   end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -4,7 +4,7 @@ class Category < ApplicationRecord
 
   validates :name, uniqueness: true
 
-  def self.category_stay_time_sort(spots_data_sort:, category_ids:)
+  def self.category_stay_time_sort(category_ids)
     category_data = Category.where(id: category_ids).index_by(&:id)
     category_ids.map { |s| category_data[s] }.pluck(:id, :stay_time).to_h
   end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -3,6 +3,8 @@ class Plan < ApplicationRecord
   has_many :spots, through: :plan_spots
   belongs_to :trip
 
+  SIXTY_MINUTES = 60
+
   def self.plans_display_data_create(elements:, plans:, trip:)
     plans.each do |plan|
       elements[plan.id] = []

--- a/app/models/plan_spot.rb
+++ b/app/models/plan_spot.rb
@@ -2,6 +2,16 @@ class PlanSpot < ApplicationRecord
   belongs_to :spot
   belongs_to :plan
 
+  def self.plan_spots_create(routes:, spots_in_vote_order:, spot_distance:, trip:)
+    routes.each_with_index do |route, index|
+      plan = Plan.create!(trip_id: trip.id, title: index + 1)
+      ordered_spots = route.map { |i| spots_in_vote_order[i] }
+      durations = Spot.move_time_between_spots(combination: route, spot_distance: spot_distance)
+      plan_spots_insert_all_data = self.create_plan_spots_insert_all_data(ordered_spots: ordered_spots, durations: durations, plan: plan)
+      self.insert_all(plan_spots_insert_all_data)
+    end
+  end
+
   def self.create_plan_spots_insert_all_data(ordered_spots:, durations:, plan:)
     ordered_spots.each_with_index.map do |spot, index|
       {

--- a/app/models/plan_spot.rb
+++ b/app/models/plan_spot.rb
@@ -2,14 +2,11 @@ class PlanSpot < ApplicationRecord
   belongs_to :spot
   belongs_to :plan
 
-  def self.plan_spots_create(routes:, spots_in_vote_order:, spot_distance:, trip:)
-    routes.each_with_index do |route, index|
-      plan = Plan.create!(trip_id: trip.id, title: index + 1)
-      ordered_spots = route.map { |i| spots_in_vote_order[i] }
-      durations = Spot.move_time_between_spots(combination: route, spot_distance: spot_distance)
-      plan_spots_insert_all_data = self.create_plan_spots_insert_all_data(ordered_spots: ordered_spots, durations: durations, plan: plan)
-      self.insert_all(plan_spots_insert_all_data)
-    end
+  def self.plan_spots_create(route:, spots_in_vote_order:, spot_distance:, plan:)
+    ordered_spots = route.map { |i| spots_in_vote_order[i] }
+    durations = Spot.move_time_between_spots(combination: route, spot_distance: spot_distance)
+    plan_spots_insert_all_data = self.create_plan_spots_insert_all_data(ordered_spots: ordered_spots, durations: durations, plan: plan)
+    self.insert_all(plan_spots_insert_all_data)
   end
 
   def self.create_plan_spots_insert_all_data(ordered_spots:, durations:, plan:)

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -106,31 +106,31 @@ class Spot < ApplicationRecord
     spots_unique_numbers.map { |s| spots_data[s] }
   end
 
-  def self.spots_all_combination_for_best_route(spots_combination:, category_ids:, category_stay_time_sort:, total_hours:, spot_distance:, travel_max_time:)
+  def self.spots_all_combination_for_best_route(spots_combination:, category_ids:, category_stay_time_in_vote_order:, total_hours:, spot_distance:, travel_max_time:)
     best_route = nil
     must_include_spots = nil
     essential_spot = nil
     self.removal_index_range(spots_combination).each do |removed|
-      total_hours, best_route, must_include_spots = self.combinations_with_removal(spots_combination: spots_combination, removed: removed, category_ids: category_ids, category_stay_time_sort: category_stay_time_sort, spot_distance: spot_distance, total_hours: total_hours, best_route: best_route, must_include_spots: must_include_spots, essential_spot: essential_spot)
+      total_hours, best_route, must_include_spots = self.combinations_with_removal(spots_combination: spots_combination, removed: removed, category_ids: category_ids, category_stay_time_in_vote_order: category_stay_time_in_vote_order, spot_distance: spot_distance, total_hours: total_hours, best_route: best_route, must_include_spots: must_include_spots, essential_spot: essential_spot)
       if total_hours < travel_max_time
         return [ [ best_route ], must_include_spots ]
       end
     end
   end
 
-  def self.spots_all_combination_for_other_routes(spots_combination:, category_ids:, category_stay_time_sort:, spot_distance:, travel_max_time:, must_include_spots:)
+  def self.spots_all_combination_for_other_routes(spots_combination:, category_ids:, category_stay_time_in_vote_order:, spot_distance:, travel_max_time:, must_include_spots:)
     other_routes = []
     must_include_spots.each do |essential_spot|
       best_route = nil
       total_hours = Float::INFINITY
-      total_hours, other_routes = self.exclude_spots_combination(spots_combination: spots_combination, travel_max_time: travel_max_time, other_routes: other_routes, total_hours: total_hours, best_route: best_route, essential_spot: essential_spot, must_include_spots:, category_ids:, spot_distance: spot_distance, category_stay_time_sort: category_stay_time_sort)
+      total_hours, other_routes = self.exclude_spots_combination(spots_combination: spots_combination, travel_max_time: travel_max_time, other_routes: other_routes, total_hours: total_hours, best_route: best_route, essential_spot: essential_spot, must_include_spots:, category_ids:, spot_distance: spot_distance, category_stay_time_in_vote_order: category_stay_time_in_vote_order)
     end
     other_routes
   end
 
-  def self.exclude_spots_combination(spots_combination:, travel_max_time:, other_routes:, total_hours:, best_route:, essential_spot:, category_ids:, category_stay_time_sort:, spot_distance:, must_include_spots:)
+  def self.exclude_spots_combination(spots_combination:, travel_max_time:, other_routes:, total_hours:, best_route:, essential_spot:, category_ids:, category_stay_time_in_vote_order:, spot_distance:, must_include_spots:)
     self.removal_index_range(spots_combination).each do |removed|
-      total_hours, best_route = self.combinations_with_removal(spots_combination: spots_combination, removed: removed, essential_spot: essential_spot, category_ids: category_ids, category_stay_time_sort: category_stay_time_sort, spot_distance: spot_distance, total_hours: total_hours, best_route: best_route, must_include_spots: must_include_spots)
+      total_hours, best_route = self.combinations_with_removal(spots_combination: spots_combination, removed: removed, essential_spot: essential_spot, category_ids: category_ids, category_stay_time_in_vote_order: category_stay_time_in_vote_order, spot_distance: spot_distance, total_hours: total_hours, best_route: best_route, must_include_spots: must_include_spots)
       if total_hours < travel_max_time
         other_routes << best_route
         break
@@ -139,14 +139,14 @@ class Spot < ApplicationRecord
     [ total_hours, other_routes ]
   end
 
-  def self.combinations_with_removal(spots_combination:, removed:, category_ids:, category_stay_time_sort:, total_hours:, best_route:, spot_distance:, must_include_spots:, essential_spot:)
+  def self.combinations_with_removal(spots_combination:, removed:, category_ids:, category_stay_time_in_vote_order:, total_hours:, best_route:, spot_distance:, must_include_spots:, essential_spot:)
     spots_combination.combination(removed).each do |removed_spot|
       if removed_spot.include?(essential_spot)
         next
       end
       spots_combination_new = spots_combination - removed_spot
       category_ids_new = self.exclude_removed_category_ids(category_ids: category_ids, removed_spot: removed_spot)
-      total_stay_time = self.calculate_total_stay_time(category_ids_new: category_ids_new, category_stay_time_sort: category_stay_time_sort)
+      total_stay_time = self.calculate_total_stay_time(category_ids_new: category_ids_new, category_stay_time_in_vote_order: category_stay_time_in_vote_order)
       total_hours, best_route, must_include_spots = self.spots_combination_permutation(spots_combination: spots_combination_new, total_hours: total_hours, best_route: best_route, total_stay_time: total_stay_time, spot_distance: spot_distance, removed_spot: removed_spot, must_include_spots: must_include_spots)
     end
     [ total_hours, best_route, must_include_spots ]
@@ -156,8 +156,8 @@ class Spot < ApplicationRecord
     category_ids.each_with_index.reject { |_, index| removed_spot.include?(index) }.map(&:first)
   end
 
-  def self.calculate_total_stay_time(category_ids_new:, category_stay_time_sort:)
-    category_ids_new.map { |id| category_stay_time_sort[id] }.sum
+  def self.calculate_total_stay_time(category_ids_new:, category_stay_time_in_vote_order:)
+    category_ids_new.map { |id| category_stay_time_in_vote_order[id] }.sum
   end
 
   def self.spots_combination_permutation(spots_combination:, total_hours:, best_route:, total_stay_time:, spot_distance:, removed_spot:, must_include_spots:)
@@ -187,6 +187,10 @@ class Spot < ApplicationRecord
   end
 
   def self.removal_index_range(spots_combination)
-    (0..spots_combination.size - 1)
+    (0...spots_combination.size)
+  end
+
+  def self.all_spot_index(number_of_spots)
+    (0...number_of_spots).to_a
   end
 end


### PR DESCRIPTION
### 概要
プラン作成に関する処理の可読性の向上と責務分離の観点からリファクタリングを行いました

### 修正内容
1. マジックナンバーの定数化
- 60を'SIX_MINUTES'として定数化しました

2. 'plans_controller'の'plan_spots'の作成処理をメソッド化
-  メソッド名: "PlanSpot.plan_spots_create"
-  処理内容: 各プランに対して、ルート順に並べたスポット(ordered_spots)およびスポット間の移動時間(duration)を元に、plan_spotsの複数レコードをinsert_allを用いて一括作成

3. "0..spots_combination.size - 1"を'メソッド化
- メソッド名: Spot.removal_index_range'

4. 'spot'モデルの'self.spots_all_combination_for_other_routes'メソッド内の処理をメソッド化
- メソッド名 : 'Spot.exclude_spots_combination'
- 処理内容 : "spots_combination"からスポットを一つずつ削除し、それに対して'Spot.combinations_with_removal'を実行する。この一連の処理を(Spot.removal_index_range)の範囲内で繰り返す処理
※(total_hours < travel_max_time）を満たした時点で繰り返し処理を中断する

5. 削除された'spot_combination'に対応する"category_id"を削除する処理をメソッド化
- メソッド名 : "Spot.exclude_removed_category_ids"
- 処理内容 : 'category_ids'の中から'Spot.exclude_spots_combination'で削除したスポットに対応するデータを削除し、新しい配列'category_ids_new'を作成するメソッド

6. 
- メソッド名 : "Spot.calculate_total_stay_time'
- 処理内容 : 'category_stay_time_in_vote_order'の中から'category_ids_new'に対応するデータを取得し、それの合計値を返すメソッド

7. 二つのスポット間の移動距離を取得する処理をメソッド化
- メソッド名 : 'Spot.move_time_between_spots'
- 処理内容 : 順路に対応したスポットの組み合わせ(combination)の中で、隣り合うスポット同士の移動時間を抽出するメソッド

8. best_routeを更新する処理をメソッド化
 - メソッド名 : 'Spot.update_best_route'
 - 処理内容 : 'total_hours'に移動時間の合計値(total_move_time)と滞在時間の合計(total_stay_time)の和を格納し、'best_route'順路の組み合わせ(combination)を、'must_include_spots'に順路から外しているスポット(removed_spot)を格納する処理
