### PR TITLE
投票されたスポットを表示する仕組みを修正

### DIFF
--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -49,9 +49,8 @@ class TripsController < ApplicationController
 
   def vote
     trip = Trip.find(params[:id])
-    voted_spot_suggestion_ids = SpotVote.where(trip_id: trip.id, user_id: current_user.id).pluck(:spot_suggestion_id)
-    voted_spot_suggestions = trip.spot_suggestions.select { |s| voted_spot_suggestion_ids.include?(s.id) }
-    not_voted_spot_suggestions = trip.spot_suggestions.reject { |s| voted_spot_suggestion_ids.include?(s.id) }
+    voted_spot_suggestions = SpotVote.voted_spot_suggestions(trip)
+    not_voted_spot_suggestions = SpotVote.not_voted_spots(trip)
     render partial: "trips/vote", locals: { trip: trip, spot_suggestions: trip.spot_suggestions, voted_spot_suggestions: voted_spot_suggestions, not_voted_spot_suggestions: not_voted_spot_suggestions }
   end
 

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -50,7 +50,7 @@ class TripsController < ApplicationController
   def vote
     trip = Trip.find(params[:id])
     voted_spot_suggestions = SpotVote.voted_spot_suggestions(trip)
-    not_voted_spot_suggestions = SpotVote.not_voted_spots(trip)
+    not_voted_spot_suggestions = SpotVote.not_voted_spot_suggestions(trip)
     render partial: "trips/vote", locals: { trip: trip, spot_suggestions: trip.spot_suggestions, voted_spot_suggestions: voted_spot_suggestions, not_voted_spot_suggestions: not_voted_spot_suggestions }
   end
 

--- a/app/models/spot_vote.rb
+++ b/app/models/spot_vote.rb
@@ -14,4 +14,17 @@ class SpotVote < ApplicationRecord
       end
     end
   end
+
+  def self.not_voted_spots(trip)
+    voted_spot_suggestion_ids = trip.spot_votes.pluck(:spot_suggestion_id).uniq
+    not_voted_spots_suggestion_ids = trip.spot_suggestions.ids - voted_spot_suggestion_ids
+    spot_suggestions = SpotSuggestion.where(id: not_voted_spots_suggestion_ids)
+    spot_suggestions
+  end
+
+  def self.voted_spot_suggestions(trip)
+    voted_spot_suggestion_ids = trip.spot_votes.pluck(:spot_suggestion_id).uniq
+    spot_suggestions = SpotSuggestion.where(id: voted_spot_suggestion_ids)
+    spot_suggestions
+  end
 end

--- a/app/models/spot_vote.rb
+++ b/app/models/spot_vote.rb
@@ -15,16 +15,16 @@ class SpotVote < ApplicationRecord
     end
   end
 
-  def self.not_voted_spots(trip)
-    voted_spot_suggestion_ids = trip.spot_votes.pluck(:spot_suggestion_id).uniq
-    not_voted_spots_suggestion_ids = trip.spot_suggestions.ids - voted_spot_suggestion_ids
-    spot_suggestions = SpotSuggestion.where(id: not_voted_spots_suggestion_ids)
-    spot_suggestions
+  def self.voted_spot_suggestion_ids(trip)
+    trip.spot_votes.pluck(:spot_suggestion_id).uniq
+  end
+
+  def self.not_voted_spot_suggestions(trip)
+    not_voted_ids = trip.spot_suggestions.ids - self.voted_spot_suggestion_ids(trip)
+    SpotSuggestion.where(id: not_voted_ids)
   end
 
   def self.voted_spot_suggestions(trip)
-    voted_spot_suggestion_ids = trip.spot_votes.pluck(:spot_suggestion_id).uniq
-    spot_suggestions = SpotSuggestion.where(id: voted_spot_suggestion_ids)
-    spot_suggestions
+    SpotSuggestion.where(id: self.voted_spot_suggestion_ids(trip))
   end
 end

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -58,8 +58,8 @@ ja:
       spot_delete: スポットの削除
       vote-limit: 投票期限まであと
       submit: 投票する
-      voted-spot: 現在投票しているスポット
-      not-voted-spot: まだ投票したスポットはありません
+      voted-spot: 現在投票されているスポット
+      not-voted-spot: まだ投票されていません
       vote-result: 投票結果
       vote-result-headline: 以下のスポットが選ばれました
       plan-create: プランの作成


### PR DESCRIPTION
### 概要
これまで自分が投票したスポットのみを表示していた画面において、全ユーザーによって投票されたスポット提案(spot_suggestions)を表示するように変更しました。

---
### 修正内容

1. 'trips'コントローラ内で以下の変数を作成
 - voted_spot_suggestions : 投票された全ての'spot_suggestions'レコードを格納
 - not_voted_spot_suggestions : 提案されたスポットの中で投票されていない'spot_suggestions'レコードを格納
 
2. 'Spot.voted_spot_suggestion_ids' メソッドを作成
-  処理内容 : 与えられた'trip'に紐づく'spot_votes'を取得し、その中の'spot_suggestion_id'カラムのみを取得(重複なし)する処理

3. 'Spot.voted_spot_suggestions' メソッドを作成
-  'SpotSuggestion'モデル内でDB内検索を実行('id'= 'Spot.voted_spot_suggestion_ids')

4. 'Spot.not_voted_spot_suggestions'メソッドを作成
-  'not_voted_ids'にtripに紐づく提案された全てのデータ(trip.spot_suggestions.ids)から'Spot.voted_spot_suggestion_ids'を排除した結果を格納
- 'SpotSuggestion'モデル内でDB内検索を実行( 'id' = 'not_voted_ids')

---