### PR TITLE
trip_users_controllerの#showの処理の一部をメソッド化

### DIFF
--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -7,7 +7,6 @@ class TripsController < ApplicationController
     @trip = Trip.new(trips_params)
     if @trip.save
       @trip.transportation_ids = params[:trip][:transportation_ids]
-
       flash[:notice] = "しおりを作成しました"
       redirect_to trip_path(@trip)
     else
@@ -37,8 +36,8 @@ class TripsController < ApplicationController
     @trip = Trip.find(params[:id])
     @trip_users = @trip.trip_users.order(is_leader: :desc)
     spot_votes = @trip.spot_votes.pluck(:spot_suggestion_id)
-    ng_spot = spot_votes.group_by { |s| s }.select { |_, value| value.size >= 2 }.keys
-    @voted_result = @trip.spot_suggestions.reject { |spot| ng_spot.include?(spot.id) }
+    ng_spot = SpotVote.ng_spot_decided(spot_votes: spot_votes, trip_users: @trip_users)
+    @voted_result = SpotSuggestion.voted_result(trip: @trip, ng_spot: ng_spot)
     @plan = Plan.find_by(id: @trip.decided_plan_id)
   end
 

--- a/app/models/spot_suggestion.rb
+++ b/app/models/spot_suggestion.rb
@@ -13,4 +13,8 @@ class SpotSuggestion < ApplicationRecord
   def current_user_voted?(current_user_voted_spot_suggestions)
     current_user_voted_spot_suggestions.include?(self.id)
   end
+
+  def self.voted_result(trip:, ng_spot:)
+    trip.spot_suggestions.reject { |spot| ng_spot.include?(spot.id) }
+  end
 end

--- a/app/models/spot_vote.rb
+++ b/app/models/spot_vote.rb
@@ -3,6 +3,8 @@ class SpotVote < ApplicationRecord
   belongs_to :trip
   belongs_to :spot_suggestion
 
+  NG_SPOT_VOTE_THRESHOLD = 0.3
+
   def self.register(trip_id:, suggestion_ids:, user_id:)
     transaction do
       Array(suggestion_ids).each do |suggestion_id|
@@ -22,5 +24,9 @@ class SpotVote < ApplicationRecord
   def self.voted_spot_suggestions(trip)
     voted_ids = trip.spot_votes.pluck(:spot_suggestion_id).uniq
     SpotSuggestion.where(id: voted_ids)
+  end
+
+  def self.ng_spot_decided(spot_votes:, trip_users:)
+    spot_votes.group_by { |s| s }.select { |_, value| value.size >= (trip_users.count * NG_SPOT_VOTE_THRESHOLD).ceil }.keys
   end
 end


### PR DESCRIPTION
### 概要
以下の処理をメソッド化することで可読性が向上しました

---
### 修正内容
1. ngスポットを決定する処理をメソッド化(ng_spot_decided)
- 処理内容 : 'spot_votes'に紐づく'spot_suggestion_id'をグループ化し、その要素数(投票数)が参加者メンバーの3割を超えていたらNGスポットとみなす処理

2. 最終的な投票結果を導き出す処理をメソッド化(voted_result)
- 処理内容 : 'spot_suggestion_ids'の中から'ng_spot'に含まれる'suggestion_ids'を排除する処理

---