### PR TITLE
homesの進行中のしおりの表示レイアウトを変更

### DIFF
--- a/app/assets/stylesheets/homes/index.scss
+++ b/app/assets/stylesheets/homes/index.scss
@@ -7,6 +7,8 @@
     border: 1px solid #ddd;
     border-radius: 8px;
     box-shadow: 0 4px 9px rgba(0,0,0,0.1);
+    padding-left: 20px;
+    padding-right: 20px;
     .title {
       text-align: center;
     }
@@ -54,10 +56,14 @@
       display: flex;
       width: 600px;
       margin: 0 auto;
+      margin-bottom: 30px;
       gap: 10px;
       flex-wrap: wrap;
       .trips-card-style {
+        &.centering {
         margin: 0 auto;
+        }
+        padding-bottom: 10px;
         width: 190px;
         border: 1px solid black;
         box-shadow: 0 4px 9px rgba(0,0,0,0.1);

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -1,7 +1,7 @@
 class HomesController < ApplicationController
   def index
-    @trips_in_progress_in_first_row = current_user.trips_in_progress_in_first_row
-    @trips_in_progress_in_other_row = current_user.trips_in_progress_in_other_row
+    @trips_in_progress_first_row = current_user.trips_in_progress_first_row
+    @trips_in_progress_other_row = current_user.trips_in_progress_other_row
     @trips_past = current_user.trips_past
   end
 end

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -1,6 +1,7 @@
 class HomesController < ApplicationController
   def index
-    @trips_in_progress = current_user.trips_in_progress
+    @trips_in_progress_in_first_row = current_user.trips_in_progress_in_first_row
+    @trips_in_progress_in_other_row = current_user.trips_in_progress_in_other_row
     @trips_past = current_user.trips_past
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,11 +20,11 @@ class User < ApplicationRecord
     avatar
   end
 
-  def trips_in_progress_in_first_row
+  def trips_in_progress_first_row
     trips.where(status: :in_progress).limit(3)
   end
 
-  def trips_in_progress_in_other_row
+  def trips_in_progress_other_row
     trips.where(status: :in_progress).offset(3)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,8 +20,12 @@ class User < ApplicationRecord
     avatar
   end
 
-  def trips_in_progress
-    trips.where(status: :in_progress)
+  def trips_in_progress_in_first_row
+    trips.where(status: :in_progress).limit(3)
+  end
+
+  def trips_in_progress_in_other_row
+    trips.where(status: :in_progress).offset(3)
   end
 
   def trips_past

--- a/app/views/homes/_trip_card.html.erb
+++ b/app/views/homes/_trip_card.html.erb
@@ -1,0 +1,25 @@
+<div class="trips-card-style <%= "centering" if centering %>">
+  <%= link_to trip_path(trip_card), class:"trip-link" do %>
+    <div class="trip-title">
+      <%= trip_card.title %>
+    </div>
+    <% if trip_card.image.attached? %>
+      <%= image_tag trip_card.image.variant(resize_to_fill: [190,130]) %>
+    <% end %>
+    <div class="member">
+      <%= t('homes.index.member')%>
+    </div>
+    <% trip_card.trip_users_sort_by_leader.each do |trip_user| %>
+      <div class="member-list">
+        <% if trip_user.is_leader == true %>
+          <i class="fa-solid fa-crown crown-icon "></i>
+        <% elsif trip_user.user.id == current_user.id %>
+          <i class="fa-solid fa-user current-user-icon "></i>  
+        <% else %>
+          <i class="fa-solid fa-user user-icon "></i>
+        <% end %>
+        <%= trip_user.user.name %>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -23,13 +23,13 @@
       </div>
     </div>
     <h2 class="in-progress-trip-title"><%= t('.in-progress-trip-title') %></h2>
-      <% if @trips_in_progress_in_first_row.present? %>
+      <% if @trips_in_progress_first_row.present? %>
         <div class="trips-container">
-          <%= render partial: "trip_card", collection: @trips_in_progress_in_first_row, :as => "trip_card", locals: { trip_users: @trip_users, centering: true } %>
+          <%= render partial: "trip_card", collection: @trips_in_progress_first_row, :as => "trip_card", locals: { trip_users: @trip_users, centering: true } %>
         </div>
-      <% if @trips_in_progress_in_other_row.present? %>
+      <% if @trips_in_progress_other_row.present? %>
         <div class="trips-container">
-          <%= render partial: "trip_card", collection: @trips_in_progress_in_other_row, :as => "trip_card", locals: { trip_users: @trip_users, centering: false } %>
+          <%= render partial: "trip_card", collection: @trips_in_progress_other_row, :as => "trip_card", locals: { trip_users: @trip_users, centering: false } %>
         </div>
       <% end %>
       <% else %>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -23,36 +23,15 @@
       </div>
     </div>
     <h2 class="in-progress-trip-title"><%= t('.in-progress-trip-title') %></h2>
-      <% if @trips_in_progress.presence %>
+      <% if @trips_in_progress_in_first_row.present? %>
         <div class="trips-container">
-          <% @trips_in_progress.each do |t| %>
-            <div class="trips-card-style">
-              <%= link_to trip_path(t), class:"trip-link" do %>
-                <div class="trip-title">
-                  <%= t.title %>
-                </div>
-                <% if t.image.attached? %>
-                  <%= image_tag t.image.variant(resize_to_fill: [190,130]) %>
-                <% end %>
-                <div class="member">
-                  <%= t('.member')%>
-                </div>
-                <% t.trip_users_sort_by_leader.each do |trip_user| %>
-                  <div class="member-list">
-                    <% if trip_user.is_leader == true %>
-                      <i class="fa-solid fa-crown crown-icon "></i>
-                    <% elsif trip_user.user.id == current_user.id %>
-                      <i class="fa-solid fa-user current-user-icon "></i>  
-                    <% else %>
-                      <i class="fa-solid fa-user user-icon "></i>
-                    <% end %>
-                    <%= trip_user.user.name %>
-                  </div>
-                <% end %>
-              <% end %>
-            </div>
-          <% end %>
+          <%= render partial: "trip_card", collection: @trips_in_progress_in_first_row, :as => "trip_card", locals: { trip_users: @trip_users, centering: true } %>
         </div>
+      <% if @trips_in_progress_in_other_row.present? %>
+        <div class="trips-container">
+          <%= render partial: "trip_card", collection: @trips_in_progress_in_other_row, :as => "trip_card", locals: { trip_users: @trip_users, centering: false } %>
+        </div>
+      <% end %>
       <% else %>
       <div class="no-in-progress-trip">
         <p><%= t('.no-in-progress-trip')%></p>


### PR DESCRIPTION
### 概要
1列目は中央寄せで順に寄せて表示
<img width="606" alt="スクリーンショット 2025-06-19 16 05 45" src="https://github.com/user-attachments/assets/c11e0df9-c474-4248-b826-47a8dabc9546" />

2列目以降は左詰めで順に表示されるように実装
<img width="658" alt="スクリーンショット 2025-06-19 16 07 52" src="https://github.com/user-attachments/assets/3ae1f1a5-7660-48bc-982d-b1837f967104" />

---
### 修正内容
1. 1列目に表示するしおりを'@trips_in_progress_first_row'に格納
- メソッド名 : current_user.trips_in_progress_first_row
- 処理内容 : 条件(status: :in_progress)に該当するcurrent_user_tripsのデータを3つまで取得

2. 2列目以降に表示するしおりを'@trips_in_progress_other_row'に格納
- メソッド名 : current_user.trips_in_progress_other_row
- 処理内容 : 条件(status: :in_progress)に該当するcurrent_user_tripsの3つ目以降のデータを取得

3. 部分テンプレート(trips/_trip_card)を作成し、１列目と2列目以降でそれぞれ呼び出すように変更
- 2列目以降を表示する際に'centering:true'を渡すことで、2列目以降のcssに'centering'を追加

---
