### PR TITLE
プランがすでに決定されている場合、しおり詳細ページでプランが表示されるように修正

### DIFF
--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -38,7 +38,11 @@ class TripsController < ApplicationController
     spot_votes = @trip.spot_votes.pluck(:spot_suggestion_id)
     ng_spot = SpotVote.ng_spot_decided(spot_votes: spot_votes, trip_users: @trip_users)
     @voted_result = SpotSuggestion.voted_result(trip: @trip, ng_spot: ng_spot)
-    @plan = Plan.find_by(id: @trip.decided_plan_id)
+    @decided_plan = Plan.find_by(id: @trip.decided_plan_id)
+    if @decided_plan.present?
+      @elements = {}
+      @decided_plan.plan_element_create(elements: @elements, plan: @decided_plan)
+    end
   end
 
   def suggestion

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -7,12 +7,12 @@ class Plan < ApplicationRecord
 
   def self.plans_display_data_create(elements:, plans:, trip:)
     plans.each do |plan|
-      elements[plan.id] = []
-      plan.plan_element_create(elements: elements)
+      plan.plan_element_create(elements: elements, plan: plan)
     end
   end
 
-  def plan_element_create(elements:)
+  def plan_element_create(elements:, plan:)
+    elements[plan.id] = []
     current_time = self.trip.start_time
     self.spots.each_with_index do |spot, i|
       if i > 0

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -2,7 +2,7 @@
   <div class="card-style">
     <%= render "shared/trip_data", trip: @trip %>
     <% if @trip.decided_plan_id.present? %>
-      <%= render "shared/plan", trip: @trip, spots: @plan.spots, plan: @plan, plan_create: false %>
+      <%= render "shared/plan", trip: @trip, spots: @decided_plan.spots, plan: @decided_plan, plan_create: false, elements: @elements[@decided_plan.id] %>
     <% else%>
       <turbo-frame id="phase">
         <% if @trip.within_spot_vote_limit_date? %>


### PR DESCRIPTION
### 概要
'trips'テーブルの'decided_plan_id'カラムにデータが存在する場合はしおり詳細ページ(trips/show.html)で対応するプランを表示するように変更しました

<img width="455" alt="スクリーンショット 2025-06-20 10 36 49" src="https://github.com/user-attachments/assets/ccae0e17-97c8-4056-bdcc-928f12cdf01f" />

---
### 修正内容
1. 'trips'コントローラの#showに以下のインスタンス変数を作成
- @decided_plan : 作成されたプランのレコード
- @elements : @decided_planをもとに作成したプラン詳細情報

2. 'if @decided_plan'がtrueの場合'shared/_plan'を呼び出しプラン詳細ページを表示

---