### PR TITLE
plan_spotsテーブルにstay_timeカラムを作成

### DIFF
--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -41,7 +41,7 @@ class TripsController < ApplicationController
     @decided_plan = Plan.find_by(id: @trip.decided_plan_id)
     if @decided_plan.present?
       @elements = {}
-      @decided_plan.plan_element_create(elements: @elements, plan: @decided_plan)
+      @decided_plan.plan_element_create(@elements)
     end
   end
 

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -7,13 +7,14 @@ class Plan < ApplicationRecord
 
   def self.plans_display_data_create(elements:, plans:, trip:)
     plans.each do |plan|
-      plan.plan_element_create(elements: elements, plan: plan)
+      plan.plan_element_create(elements)
     end
   end
 
-  def plan_element_create(elements:, plan:)
-    elements[plan.id] = []
+  def plan_element_create(elements)
+    elements[self.id] = []
     current_time = self.trip.start_time
+    plan_spots = PlanSpot.where(plan_id: self.id).index_by(&:spot_id)
     self.spots.each_with_index do |spot, i|
       if i > 0
         move_duration = self.spots[i - 1].move_duration(self)
@@ -27,11 +28,11 @@ class Plan < ApplicationRecord
       end
       elements[self.id] << {
         time: current_time.strftime("%H:%M"),
-        content: spot.category.stay_time,
+        content: plan_spots[spot.id].stay_time,
         spot_name: spot.spot_name,
         spot_id: spot.id
       }
-      current_time += spot.category.stay_time.minutes
+      current_time += plan_spots[spot.id].stay_time.minutes
     end
     elements[self.id] << {
       time: current_time.strftime("%H:%M"),

--- a/app/models/plan_spot.rb
+++ b/app/models/plan_spot.rb
@@ -14,6 +14,7 @@ class PlanSpot < ApplicationRecord
       {
         plan_id: plan.id,
         order: index + 1,
+        stay_time: spot.category.stay_time,
         spot_id: spot.id,
         duration: durations[index] || 0
       }

--- a/app/views/plans/index.html.erb
+++ b/app/views/plans/index.html.erb
@@ -6,7 +6,7 @@
       <%= form_with url: trip_decided_plan_path(@trip.id), method: :post do |f| %>
         <div class="plans-container">
           <% @plans.each_with_index do |plan, plan_index| %>
-            <%= render partial: "shared/plan", :as => "plan", locals: { trip: @trip, plan: plan, plan_index: plan_index, size: @plans.size, plan_create: true, elements: @elements[plan.id]} %>
+            <%= render partial: "shared/plan", :as => "plan", locals: { trip: @trip, plan: plan, plan_index: plan_index, size: @plans.size, plan_create: true, elements: @elements[plan.id]}%>
           <% end %>
         </div>
         <%= hidden_field_tag :selected_plan_id, nil, id: "selected_plan_id_field" %>

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -2,7 +2,7 @@
   <div class="card-style">
     <%= render "shared/trip_data", trip: @trip %>
     <% if @trip.decided_plan_id.present? %>
-      <%= render "shared/plan", trip: @trip, spots: @decided_plan.spots, plan: @decided_plan, plan_create: false, elements: @elements[@decided_plan.id] %>
+      <%= render "shared/plan", trip: @trip, spots: @decided_plan.spots, plan: @decided_plan, plan_create: false, elements: @elements[@decided_plan.id], edit_icon: true %>
     <% else%>
       <turbo-frame id="phase">
         <% if @trip.within_spot_vote_limit_date? %>

--- a/db/migrate/20250606060655_create_plan_spots.rb
+++ b/db/migrate/20250606060655_create_plan_spots.rb
@@ -4,6 +4,7 @@ class CreatePlanSpots < ActiveRecord::Migration[8.0]
       t.timestamps
       t.integer :order
       t.integer :duration
+      t.integer :stay_time
       t.references :spot, null: false, foreign_key: { on_update: :cascade, on_delete: :cascade }
       t.references :plan, null: false, foreign_key: { on_update: :cascade, on_delete: :cascade }
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -76,6 +76,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_12_080343) do
     t.datetime "updated_at", null: false
     t.integer "order"
     t.integer "duration"
+    t.integer "stay_time"
     t.bigint "spot_id", null: false
     t.bigint "plan_id", null: false
     t.index ["plan_id"], name: "index_plan_spots_on_plan_id"


### PR DESCRIPTION
### 概要
'plan_spots'テーブルに'stay_time'カラムを追加し、プラン詳細画面でスポットの滞在時間を'spot.category.stay_time'ではなく、'plan_spots.stay_time'から取得するように変更しました。


### 修正内容
1. プラン詳細表示におけるスポットの滞在時間の取得方法を変更
- plan_spots = PlanSpot.where(plan_id: self.id).index_by(&:spot_id) : 'plan.id'に紐づく全ての'plan_spot'を取得
- plan_spots[spot.id].stay_time : 'plan_spots'の中で'spot.id'と一致するデータのみを抽出し、その'stay_time'を取得

2. 'plan_spot'を作成する際に必要な'plan_spots_insert_all_data'に'stay_time'を追加

---