### PR TITLE
プランの編集ページと更新機能を追加

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,3 +23,4 @@
 @use "plans/index.scss" as plans_index;
 @use "shared/trip_data.scss" as shared_trip_data;
 @use "shared/plan.scss" as shared_plan;
+@use "plans/edit.scss" as plans_edit;

--- a/app/assets/stylesheets/plans/edit.scss
+++ b/app/assets/stylesheets/plans/edit.scss
@@ -1,0 +1,100 @@
+.plan-edit{
+  .card-style {
+    margin: 0 auto;
+    margin-bottom: 100px;
+    width: 600px;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    box-shadow: 0 4px 9px rgba(0, 0, 0, 0.1);
+    .plan-container {
+      margin: 0 auto;
+      p {
+        font-size: 25px;
+        font-weight: bold;
+        padding-top: 10px;
+      } 
+      position: relative;
+      border:1px solid black;
+      border-radius: 5px;
+      scroll-snap-align: start;
+      width: 550px;
+      padding: 10px;
+      text-align: center;
+        .selected {
+        display: none;
+      }
+      .spots-container {
+        display: flex;
+        justify-content: space-around;
+        margin: 0 auto;
+        width: 500px;
+        flex-wrap: wrap;
+        margin-bottom: 50px;
+        .spot {
+          border: 1px solid black;
+          border-radius: 10px;
+          width: 150px;
+        }
+        .image {
+          width: 100px;
+          height: 100px;
+        }
+      }
+      .guide-book {
+        display: table;
+        width: 550px;
+        margin: 0 auto;
+        margin-bottom: 30px;
+        border: 1px solid black;
+        border-radius: 10px 10px 0 0;
+        overflow: hidden;
+        .guide-headline {
+          display: table-row;
+          background-color: #d3d3d3;
+          text-align: center;
+          font-weight: bold;
+        }
+        .guide-row {
+          display: table-row;
+          width: 100%;
+          .stay-time-form {
+            width:50px;
+            text-align: center;
+            color: blue;
+            font-size: 20px;
+            border: 1px solid black;
+            border-radius: 4px;
+          }
+        }
+        .time-cell {
+          padding: 10px;
+          display: table-cell;
+          border-right: 1px solid black;
+          text-align: center;
+          width: 150px;
+          font-size: 20px;
+        }
+        .content-cell {
+          padding: 10px;
+          display: table-cell;
+          text-align: center;
+          width: 400px;
+          font-size: 20px;
+        }
+        .spot_link {
+          color: blue;
+        }
+      }
+      .update-form {
+        margin-bottom: 50px;
+      }
+      .update-button {
+        font-size: 25px;
+        background-color: #007bff;
+        color: white;
+        border: 1px solid #007bff;
+        border-radius: 4px;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/shared/plan.scss
+++ b/app/assets/stylesheets/shared/plan.scss
@@ -47,6 +47,9 @@
       height: 100px;
     }
   }
+  .edit-icon {
+    text-align: right;
+  }
   .guide-book {
     display: table;
     width: 550px;

--- a/app/views/plans/edit.html.erb
+++ b/app/views/plans/edit.html.erb
@@ -1,0 +1,62 @@
+<div class="plan-edit">
+  <div class="card-style">
+    <%= render "shared/trip_data", trip: @trip %>
+    <div class="plan-container">
+      <p>プラン<%= @plan.title %></p>
+      <div class="spots-container">
+        <% @plan.spots.each do |spot| %>
+          <%= render partial: "shared/plan_spots", locals: { trip: @trip, spot: spot } %>
+        <% end %>
+      </div>
+      <%= form_with url: trip_plan_path(@trip.id, @plan.id), method: :patch do |f| %>
+        <div class="guide-book">
+          <div class="guide-headline">
+            <div class="time-cell">
+              <%= t('plans.index.time')%>
+            </div>
+            <div class="content-cell">
+              <%= t('plans.index.content') %>
+            </div>
+          </div>
+          <% @elements[@plan.id].each_with_index do |element, index| %>
+            <% if index == @elements[@plan.id].length - 1 %>
+              <div class="guide-row">
+                <div class="time-cell">
+                  <%= element[:time] %>
+                </div>
+                <div class="content-cell">
+                  <%= element[:content] %>
+                </div>
+              </div>
+              <% break %>
+            <% end %>
+            <% if index.even? %>
+              <div class="guide-row">
+                <div class="time-cell">
+                  <%= element[:time] %>
+                </div>
+                <div class="content-cell">
+                  <%= element[:spot_name] %>(<%= t('plans.index.stay-time') %>:
+                  <%= hidden_field_tag "update_dates[][spot_id]", element[:spot_id] %>
+                  <%= number_field_tag "update_dates[][stay_time]", element[:content], class: "stay-time-form" %>分)
+                </div>
+              </div>
+            <% else %>
+              <div class="guide-row">
+                <div class="time-cell">
+                  <%= element[:time] %>
+                </div>
+                <div class="content-cell">
+                  <%= t('plans.index.move-time') %>(<%= element[:content]%>分)
+                </div>
+              </div>
+            <% end %>
+          <% end %>
+        </div>
+        <div class="update-form">
+          <%= f.submit t('.update'), class:"update-button" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/plans/index.html.erb
+++ b/app/views/plans/index.html.erb
@@ -6,7 +6,7 @@
       <%= form_with url: trip_decided_plan_path(@trip.id), method: :post do |f| %>
         <div class="plans-container">
           <% @plans.each_with_index do |plan, plan_index| %>
-            <%= render partial: "shared/plan", :as => "plan", locals: { trip: @trip, plan: plan, plan_index: plan_index, size: @plans.size, plan_create: true, elements: @elements[plan.id]}%>
+            <%= render partial: "shared/plan", :as => "plan", locals: { trip: @trip, plan: plan, plan_index: plan_index, size: @plans.size, plan_create: true, elements: @elements[plan.id], edit_icon: false }%>
           <% end %>
         </div>
         <%= hidden_field_tag :selected_plan_id, nil, id: "selected_plan_id_field" %>

--- a/app/views/shared/_plan.html.erb
+++ b/app/views/shared/_plan.html.erb
@@ -8,6 +8,13 @@
       <%= render partial: "shared/plan_spots", locals: { trip: trip, spot: spot } %>
     <% end %>
   </div>
+  <% if edit_icon %>
+    <div class="edit-icon">
+      <%= link_to edit_trip_plan_path(trip.id, plan.id) do %>
+        <i class="fa-solid fa-pen-to-square fa-2x"></i>
+      <% end %>
+    </div>
+  <% end %>
   <div class="guide-book">
     <div class="guide-headline">
       <div class="time-cell">

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -100,3 +100,5 @@ ja:
       wait-detail2: しばらくお待ちください🙇‍♂️
       stay-time: 滞在
       finish: 終了
+    edit:
+      update: 変更する


### PR DESCRIPTION
### 概要
プランの編集ページを作成し、そこでスポットの滞在時間を編集+反映されたプランの再生成ができる機能を追加しました。
これにより自動で作成されたプランに対して任意でスポットの滞在時間を変更できるようになります

---
### 修正内容
1. プラン編集ページの作成
- 'plans.edit.html'の作成
- 'number_filed_tag'を用いて滞在時間を入力できるフォームを作成
- 'hidden_field_tag'を用いてパラメータの構造を整理

2. プランを更新する処理を作成(plans_controller#update)
- 'transaction'を用いて複数の'PlanSpot'レコードを一括で更新
- 成功したら'trip_edit_plan_path'へリダイレクト
- 失敗したら'transaction'処理により元の状態に戻して'edit'を再表示

---