### PR TITLE
プランの滞在時間を更新する際に、観光時間を超えてしまう場合はエラーが出るように修正

### DIFF
--- a/app/assets/stylesheets/plans/edit.scss
+++ b/app/assets/stylesheets/plans/edit.scss
@@ -7,7 +7,6 @@
     border-radius: 8px;
     box-shadow: 0 4px 9px rgba(0, 0, 0, 0.1);
     .plan-container {
-      margin: 0 auto;
       p {
         font-size: 25px;
         font-weight: bold;
@@ -38,6 +37,22 @@
         .image {
           width: 100px;
           height: 100px;
+        }
+      }
+      .trip-time-container {
+        display: flex;
+        justify-content: space-around;
+        margin-bottom: 50px;
+        font-size: 20px;
+        .trip-start-time {
+          width: 200px;
+          border: 1px solid black;
+          border-radius: 5px;
+        }
+        .trip-finish-time {
+          width: 200px;
+          border: 1px solid black;
+          border-radius: 5px;
         }
       }
       .guide-book {

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -18,7 +18,7 @@ class PlansController < ApplicationController
 
     total_hours = Float::INFINITY
 
-    travel_max_time = (trip.finish_time - trip.start_time)/Plan::SIXTY_MINUTES
+    trip_max_time = (trip.finish_time - trip.start_time)/Plan::SIXTY_MINUTES
 
     spots_unique_numbers = params[:spot_unique_numbers]
     spots_in_vote_order = Spot.spots_in_vote_order(spots_unique_numbers)
@@ -28,10 +28,10 @@ class PlansController < ApplicationController
 
     spots_combination = Spot.all_spot_index(number_of_spots)
     # 各スポットの組み合わせパターンを検討し、制限時間内に収まる最短ルートを取得
-    routes, must_include_spots = Spot.spots_all_combination_for_best_route(spots_combination: spots_combination, category_ids: category_ids, category_stay_time_in_vote_order: category_stay_time_in_vote_order, total_hours: total_hours, spot_distance: spot_distance, travel_max_time: travel_max_time)
+    routes, must_include_spots = Spot.spots_all_combination_for_best_route(spots_combination: spots_combination, category_ids: category_ids, category_stay_time_in_vote_order: category_stay_time_in_vote_order, total_hours: total_hours, spot_distance: spot_distance, trip_max_time: trip_max_time)
 
     if must_include_spots.present?
-      routes += Spot.spots_all_combination_for_other_routes(spots_combination: spots_combination, category_ids: category_ids, category_stay_time_in_vote_order: category_stay_time_in_vote_order, spot_distance: spot_distance, travel_max_time: travel_max_time, must_include_spots: must_include_spots)
+      routes += Spot.spots_all_combination_for_other_routes(spots_combination: spots_combination, category_ids: category_ids, category_stay_time_in_vote_order: category_stay_time_in_vote_order, spot_distance: spot_distance, trip_max_time: trip_max_time, must_include_spots: must_include_spots)
     end
     begin
       ActiveRecord::Base.transaction do
@@ -57,23 +57,37 @@ class PlansController < ApplicationController
   end
 
   def update
-    plan = Plan.find(params[:id])
-    trip = plan.trip
+    @plan = Plan.find(params[:id])
+    @trip = @plan.trip
+    @elements = {}
+    @plan.plan_element_create(@elements)
+    trip_max_time = (@trip.finish_time - @trip.start_time)/Plan::SIXTY_MINUTES
     begin
       ActiveRecord::Base.transaction do
         plan_params[:update_dates].each do |update_date|
           spot_id = update_date["spot_id"].to_i
           stay_time = update_date["stay_time"].to_i
-          plan_spot = PlanSpot.find_by!(spot_id: spot_id, plan_id: plan.id)
+          plan_spot = PlanSpot.find_by!(spot_id: spot_id, plan_id: @plan.id)
           plan_spot.update!(stay_time: stay_time)
         end
-        flash[:notice] = "更新に成功しました"
-        redirect_to edit_trip_plan_path(trip, plan)
+        total_times = 0
+        @plan.plan_spots.each do |plan_spot|
+          total_times += (plan_spot.stay_time + plan_spot.duration)
+        end
+        if trip_max_time >= total_times
+          flash[:notice] = "更新に成功しました"
+          redirect_to edit_trip_plan_path(@trip, @plan)
+        else
+          raise "滞在時間と移動時間の合計が観光可能時間を超えています"
+        end
       end
+    rescue RuntimeError
+      flash.now[:alert] = "滞在時間と移動時間の合計が観光可能時間を超えています"
+      render :edit, status: :unprocessable_entity
     rescue => e
       Rails.logger.error "編集処理でエラー発生: #{e.class} - #{e.message}"
-      flash[:alert]  = "プランを更新することができませんでした"
-      render :edit
+      flash.now[:alert] = "プランを更新することができませんでした"
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -106,32 +106,32 @@ class Spot < ApplicationRecord
     spots_unique_numbers.map { |s| spots_data[s] }
   end
 
-  def self.spots_all_combination_for_best_route(spots_combination:, category_ids:, category_stay_time_in_vote_order:, total_hours:, spot_distance:, travel_max_time:)
+  def self.spots_all_combination_for_best_route(spots_combination:, category_ids:, category_stay_time_in_vote_order:, total_hours:, spot_distance:, trip_max_time:)
     best_route = nil
     must_include_spots = nil
     essential_spot = nil
     self.removal_index_range(spots_combination).each do |removed|
       total_hours, best_route, must_include_spots = self.combinations_with_removal(spots_combination: spots_combination, removed: removed, category_ids: category_ids, category_stay_time_in_vote_order: category_stay_time_in_vote_order, spot_distance: spot_distance, total_hours: total_hours, best_route: best_route, must_include_spots: must_include_spots, essential_spot: essential_spot)
-      if total_hours < travel_max_time
+      if total_hours < trip_max_time
         return [ [ best_route ], must_include_spots ]
       end
     end
   end
 
-  def self.spots_all_combination_for_other_routes(spots_combination:, category_ids:, category_stay_time_in_vote_order:, spot_distance:, travel_max_time:, must_include_spots:)
+  def self.spots_all_combination_for_other_routes(spots_combination:, category_ids:, category_stay_time_in_vote_order:, spot_distance:, trip_max_time:, must_include_spots:)
     other_routes = []
     must_include_spots.each do |essential_spot|
       best_route = nil
       total_hours = Float::INFINITY
-      total_hours, other_routes = self.exclude_spots_combination(spots_combination: spots_combination, travel_max_time: travel_max_time, other_routes: other_routes, total_hours: total_hours, best_route: best_route, essential_spot: essential_spot, must_include_spots:, category_ids:, spot_distance: spot_distance, category_stay_time_in_vote_order: category_stay_time_in_vote_order)
+      total_hours, other_routes = self.exclude_spots_combination(spots_combination: spots_combination, trip_max_time: trip_max_time, other_routes: other_routes, total_hours: total_hours, best_route: best_route, essential_spot: essential_spot, must_include_spots:, category_ids:, spot_distance: spot_distance, category_stay_time_in_vote_order: category_stay_time_in_vote_order)
     end
     other_routes
   end
 
-  def self.exclude_spots_combination(spots_combination:, travel_max_time:, other_routes:, total_hours:, best_route:, essential_spot:, category_ids:, category_stay_time_in_vote_order:, spot_distance:, must_include_spots:)
+  def self.exclude_spots_combination(spots_combination:, trip_max_time:, other_routes:, total_hours:, best_route:, essential_spot:, category_ids:, category_stay_time_in_vote_order:, spot_distance:, must_include_spots:)
     self.removal_index_range(spots_combination).each do |removed|
       total_hours, best_route = self.combinations_with_removal(spots_combination: spots_combination, removed: removed, essential_spot: essential_spot, category_ids: category_ids, category_stay_time_in_vote_order: category_stay_time_in_vote_order, spot_distance: spot_distance, total_hours: total_hours, best_route: best_route, must_include_spots: must_include_spots)
-      if total_hours < travel_max_time
+      if total_hours < trip_max_time
         other_routes << best_route
         break
       end

--- a/app/views/plans/edit.html.erb
+++ b/app/views/plans/edit.html.erb
@@ -8,6 +8,16 @@
           <%= render partial: "shared/plan_spots", locals: { trip: @trip, spot: spot } %>
         <% end %>
       </div>
+      <div class="trip-time-container">
+        <div class="trip-start-time">
+          <%= t('.trip-start-time') %><br>
+          <%= @trip.start_time.strftime("%H:%M") %>
+        </div>
+        <div class="trip-finish-time">
+          <%= t('.trip-finish-time') %><br>
+          <%= @trip.finish_time.strftime("%H:%M") %>
+        </div>
+      </div>
       <%= form_with url: trip_plan_path(@trip.id, @plan.id), method: :patch do |f| %>
         <div class="guide-book">
           <div class="guide-headline">

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -102,3 +102,5 @@ ja:
       finish: 終了
     edit:
       update: 変更する
+      trip-start-time: 観光開始時間
+      trip-finish-time: 観光終了時間


### PR DESCRIPTION
### 概要
プランの滞在時間変更後のプラン全体の時間が、旅行の観光可能時間を超えてしまう場合は「滞在時間と移動時間の合計が観光可能時間を超えています」というメッセージとともにエラーが発生するように修正しました。これにより適切な時間以外が入力できないようになりました。

観光可能時間を表す変数名を全て'trip_max_time'に統一しました

---
### 修正内容
**1. 滞在時間に対してバリデーションを作成**
- 'plans#update' の'transaction'処理に観光可能時間(trip_max_time)とプラン全体の時間(total_times)を比較する処理を追加

**2. 観光可能時間を表す変数を'trip_max_time'に統一**

**3. プラン編集ページで旅行の開始時間と終了時間が確認できるようにレイアウトを修正**
<img width="616" alt="スクリーンショット 2025-06-21 17 26 03" src="https://github.com/user-attachments/assets/e8848bc8-4eca-495d-a479-5eb7be405f7b" />

---
