### PR TITLE
しおりの移動時間と滞在時間を15分単位で表示するように変更

### DIFF
--- a/app/assets/stylesheets/plans/edit.scss
+++ b/app/assets/stylesheets/plans/edit.scss
@@ -59,7 +59,6 @@
         display: table;
         width: 550px;
         margin: 0 auto;
-        margin-bottom: 30px;
         border: 1px solid black;
         border-radius: 10px 10px 0 0;
         overflow: hidden;
@@ -99,6 +98,10 @@
         .spot_link {
           color: blue;
         }
+      }
+      .stay-time-alert {
+        margin-bottom: 30px;
+        text-align: right;
       }
       .update-form {
         margin-bottom: 50px;

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -172,7 +172,7 @@ class Spot < ApplicationRecord
   end
 
   def self.move_time_between_spots(combination:, spot_distance:)
-    combination.each_cons(2).map { |a, b| spot_distance[:duration][a][b] }
+    combination.each_cons(2).map { |a, b| self.time_ceil_fifteen(spot_distance[:duration][a][b]) }
   end
 
   def self.update_best_route(total_move_time:, total_stay_time:, total_hours:, combination:, removed_spot:)
@@ -220,5 +220,9 @@ class Spot < ApplicationRecord
 
   def self.last_page_if_not_last(current_page:, total_spots:, total_page:)
     current_page * Spot::PER_PAGE < total_spots ? total_page : nil
+  end
+
+  def self.time_ceil_fifteen(duration)
+    (duration.to_f / 15).ceil * 15
   end
 end

--- a/app/views/plans/edit.html.erb
+++ b/app/views/plans/edit.html.erb
@@ -48,7 +48,7 @@
                 <div class="content-cell">
                   <%= element[:spot_name] %>(<%= t('plans.index.stay-time') %>:
                   <%= hidden_field_tag "update_dates[][spot_id]", element[:spot_id] %>
-                  <%= number_field_tag "update_dates[][stay_time]", element[:content], class: "stay-time-form" %>分)
+                  <%= number_field_tag "update_dates[][stay_time]", element[:content], step: 15, class: "stay-time-form" %>分)
                 </div>
               </div>
             <% else %>
@@ -62,6 +62,9 @@
               </div>
             <% end %>
           <% end %>
+        </div>
+        <div class="stay-time-alert">
+          <%= t('.stay-time-alert')%>
         </div>
         <div class="update-form">
           <%= f.submit t('.update'), class:"update-button" %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -104,3 +104,4 @@ ja:
       update: 変更する
       trip-start-time: 観光開始時間
       trip-finish-time: 観光終了時間
+      stay-time-alert: ※滞在時間は15分単位で入力してください

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,7 +13,7 @@ require "csv"
 Category.create(name: "sightseeing", stay_time: 90)
 Category.create(name: "shopping", stay_time: 60)
 Category.create(name: "leisure_land", stay_time: 300)
-Category.create(name: "nature", stay_time: 50)
+Category.create(name: "nature", stay_time: 45)
 Category.create(name: "restaurant", stay_time: 60)
 Category.create(name: "other", stay_time: 60)
 


### PR DESCRIPTION
### 概要
以下の変更を加えました
- 'PlanSpot'の'duration'を15分単位に整形してから保存するように変更
- 'plans/edit.html'において滞在時間の入力フォーム(number_filed_tag)にオプション(step = 15)を追加

これによりスポットの滞在時間と移動時間は全て15分単位で扱うことができるようになりました

### 修正内容
**1. 'spot.rb'に'duration'を15分単位に整形するクラスメソッドを作成**
- メソッド名 : Spot.time_ceil_fifteen(duration)
- 処理内容 : 'duration'15で割った値の小数点を切り上げ、それに対して15をかけることで15分単位の数値に整形

**2. 'PlanSpot'レコードの作成時とプラン作成ロジックにおいて'duration'を15分単位に整形**
- 'Spot.move_time_between_spots(combination:, spot_distance:)'のspot_distanceに' Spot.time_ceil_fifteen(duration)'メソッドを適用

**3. 'plans/edit.html'において入力できる数値を15分単位のみに変更**
- 'number_filed_tag'にオプション(step = 15)を追加

**4. seeds.rbで追加するCategoriesテーブルの初期値について、'stay_time'を15分単位に変更**

---