### PR TITLE
スポットの画像を全てactive_storageに保存し、そこから開くように変更

### DIFF
--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -1,10 +1,13 @@
 class Spot < ApplicationRecord
+  require "open-uri"
+
   has_many :spot_suggestions
   has_many :trips, through: :spot_suggestions, dependent: :destroy
   has_many :keyword_spots
   has_many :keywords, through: :keyword_spots, dependent: :destroy
   has_many :plan_spots
   has_many :plans, through: :plan_spots
+  has_one_attached :image
   belongs_to :category
 
   PER_PAGE = 10
@@ -39,6 +42,8 @@ class Spot < ApplicationRecord
     spots_insert_all_data = self.spots_insert_all_data(spot_details: spot_details, spot_category_hash: spot_category_hash)
 
     insert_all!(spots_insert_all_data)
+
+    Spot.image_save(spots_unique_numbers)
 
     spot_ids = where(unique_number: spots_unique_numbers).ids
 
@@ -224,5 +229,13 @@ class Spot < ApplicationRecord
 
   def self.time_ceil_fifteen(duration)
     (duration.to_f / 15).ceil * 15
+  end
+
+  def self.image_save(spots_unique_numbers)
+    spots = where(unique_number: spots_unique_numbers)
+    spots.each do |spot|
+      file = URI.open(spot.image_url)
+      spot.image.attach(io: file, filename: "#{spot.spot_name}.jpg")
+    end
   end
 end

--- a/app/views/shared/_plan_spots.erb
+++ b/app/views/shared/_plan_spots.erb
@@ -1,4 +1,4 @@
 <div class="spot">
   <%= link_to spot.spot_name.truncate(6, omission: "‥"), trip_spot_path(trip.id, spot.id) %>
-  <%= image_tag spot.image_url, class:"image" %>
+  <%= image_tag spot.image, class:"image" if spot.image.attached? %>
 </div>

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -1,5 +1,5 @@
 <div class="spot-container">
-  <%= image_tag spot.image_url, class:"image" %>
+  <%= image_tag spot.image, class:"image"  if spot.image.attached? %>
   <div class="spot-name-address">
     <div class="spot-name">
       <%= link_to spot.spot_name, trip_spot_path(trip_id: params[:trip_id], id: spot.id), data: { turbo_frame: "_top"} %>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -4,7 +4,7 @@
       <%= @spot.spot_name %>
     </div>
     <div class="image">
-      <%= image_tag @spot.image_url, class:"image-size"%>
+      <%= image_tag @spot.image, class:"image-size" if @spot.image.attached? %>
     </div>
     <div class="spot-group">
       <span class="label"><%= Spot.human_attribute_name(:address) %></span>

--- a/app/views/trips/_spot.html.erb
+++ b/app/views/trips/_spot.html.erb
@@ -4,7 +4,7 @@
       <%= check_box_tag "spot_suggestion_ids[]", spot_suggestion.id, false, id: "spot_suggestion_ids_#{spot_suggestion.id}" %>
     <% end %>
     <%= link_to spot_suggestion.spot.spot_name.truncate(6, omission: "‥"), trip_spot_path(trip, spot_suggestion.spot), data: { turbo_frame: "_top" } %><br>
-    <%= image_tag spot_suggestion.spot.image_url, class:"image" %>
+    <%= image_tag spot_suggestion.spot.image, class:"image" if spot_suggestion.spot.image.attached? %>
     <% if show_delete_link && spot_suggestion.created_by?(current_user) %>
       <%= link_to trip_spot_suggestion_path(trip_id: params[:id], spot_id: spot_suggestion.spot.id), method: :delete, data: { confirm: "本当に削除しますか？" }, class:"spot-delete-link" do %>
         <i class="fa-solid fa-xmark"></i>


### PR DESCRIPTION
### 概要
スポット検索でAPIを叩いた際に、同時にスポットの画像を'ActiveStorage'に保存し、ビューから画像を開く際には'ActiveStorage'から開くようにすることで、APIへのリクエスト回数を減らすことができた

---
### 修正内容
**1. 取得したスポットの画像を'ActiveStorage'に保存する処理をメソッド化**
- スポット名 : 'Spot.image_save'
- 処理内容 : 'spot.image_url'からファイルデータを取得し、それを'Spot'モデルに添付

**2. 各ビューでスポットの画像を開く場合は'ActiveStorage'から開く**

---