### PR TITLE
spotsテーブルの構造整理と格納するデータの整形

### DIFF
--- a/app/assets/stylesheets/spots/show.scss
+++ b/app/assets/stylesheets/spots/show.scss
@@ -31,6 +31,7 @@
         font-size: 20px;
       }
       .body {
+        width: 400px;
         margin-left: 20px;
         font-size: 15px;
       }

--- a/app/assets/stylesheets/spots/show.scss
+++ b/app/assets/stylesheets/spots/show.scss
@@ -31,6 +31,7 @@
         font-size: 20px;
       }
       .body {
+        word-break: break-all;
         width: 400px;
         margin-left: 20px;
         font-size: 15px;

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -97,9 +97,11 @@ class Spot < ApplicationRecord
       {
       unique_number: spot_detail["id"],
       spot_name: spot_detail.dig("displayName", "text"),
+      phone_number: spot_detail.dig("internationalPhoneNumber")&.sub(/\A\+81\s?/, "0"),
+      opening_hours: spot_detail.dig("regularOpeningHours", "weekdayDescriptions")&.join("\n\n"),
       URL: spot_detail["websiteUri"],
       spot_value: spot_detail["rating"],
-      address: spot_detail["formattedAddress"],
+      address: spot_detail["formattedAddress"]&.sub(/\A日本、/, ""),
       image_url: "https://places.googleapis.com/v1/#{spot_detail.dig("photos", 0, "name")}/media?maxWidthPx=800&key=#{ENV["API_KEY"]}",
       category_id: category_id
       }

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -15,12 +15,12 @@
       <span class="body"><%= @spot.phone_number %></span>
     </div>
     <div class="spot-group">
-      <span class="label"><%= Spot.human_attribute_name(:opening_hours) %>
-      <span class="body"><%= @spot.opening_hours %></span>
+      <span class="label"><%= Spot.human_attribute_name(:opening_hours) %></span>
+      <span class="body"><%=  simple_format(@spot.opening_hours) %></span>
     </div>
     <div class="spot-group">
       <span class="label"><%= Spot.human_attribute_name(:genre) %></span>
-      <span class="body"><%= @spot.genre %></span>
+      <span class="body"><%= @spot.category.name %></span>
     </div>
     <div class="spot-group">
       <span class="label"><%= Spot.human_attribute_name(:spot_value) %></span>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -28,7 +28,7 @@
     </div>
     <div class="spot-group">
       <span class="label"><%= Spot.human_attribute_name(:URL) %></span>
-      <span class="body"><%= link_to @spot.URL, @spot.URL, target: :_blank%></span>
+      <span class="body"><%= link_to @spot.URL, @spot.URL, target: :_blank %></span>
     </div>
   </div>
   <div class="search_page_link">

--- a/db/migrate/20250422033705_create_spots.rb
+++ b/db/migrate/20250422033705_create_spots.rb
@@ -3,14 +3,10 @@ class CreateSpots < ActiveRecord::Migration[8.0]
     create_table :spots do |t|
       t.string :spot_name
       t.string :unique_number
-      t.integer :phone_number
+      t.string :phone_number
       t.string :opening_hours
-      t.string :closing_day
-      t.string :genre
       t.string :spot_value
-      t.string :other
       t.text :URL
-      t.string :stay_time
       t.string :address
       t.text :image_url
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -120,14 +120,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_12_080343) do
   create_table "spots", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "spot_name"
     t.string "unique_number"
-    t.integer "phone_number"
+    t.string "phone_number"
     t.string "opening_hours"
-    t.string "closing_day"
-    t.string "genre"
     t.string "spot_value"
-    t.string "other"
     t.text "URL"
-    t.string "stay_time"
     t.string "address"
     t.text "image_url"
     t.datetime "created_at", null: false


### PR DESCRIPTION
### 概要
'spots'テーブルの不要なカラムの削除と、データ形式の変更を行いました
またスポット検索の結果を'spots'テーブルに保存する際のデータの整形を行いました

---
### 修正内容
**1. 'spots'テーブルの以下のカラムを削除**
- closing_day
- genre
- other
- stay_time

**2. スポット検索の結果を格納する際のデータの整形**
- phone_number : '+81'を0に置き換えて日本語対応形式に変更
- address : '日本、'を削除
- opening_hours : 要素ごとに二つの改行(/n/n)を追加

**3. スポットの詳細情報を表示する際に、'opening_hours'の改行(/n)を反映させるために'simple_format'を追加**

---