### PR TITLE
メンバーがプラン作成待機画面に遷移する際にプランを作成してしまう挙動を修正

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -12,6 +12,10 @@ class PlansController < ApplicationController
   end
   def create
     trip = Trip.find(params[:trip_id])
+    unless TripUser.current_user_is_leader?(trip: trip, current_user: current_user)
+      redirect_to trip_plans_path
+      return
+    end
     spot_distance = DistanceMatrix.spot_distance(origins: params[:spot_unique_numbers], destinations: params[:spot_unique_numbers], mode: "driving")
 
     number_of_spots = spot_distance[:duration].size

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -3,7 +3,7 @@
     <%= render "shared/trip_data", trip: @trip %>
     <% if @trip.decided_plan_id.present? %>
       <%= render "shared/plan", trip: @trip, spots: @decided_plan.spots, plan: @decided_plan, plan_create: false, elements: @elements[@decided_plan.id], edit_icon: true %>
-    <% else%>
+    <% else %>
       <turbo-frame id="phase">
         <% if @trip.within_spot_vote_limit_date? %>
           <%= render partial: "suggestion", locals: { trip: @trip, spot_suggestions: @trip.spot_suggestions, show_delete_link: true } %>


### PR DESCRIPTION
### 概要
メンバーが「プラン作成」ボタンを押した際、プラン作成待機画面へ遷移し、リーダーによるプラン作成を待つ設計でした。
しかし、待機画面への遷移時にも誤ってプランが作成されてしまう仕様となっており、プランが重複して作成される不具合が発生していました。
今回の修正により、この重複作成を防止できるようになりました。

---
### 修正内容
1. 'plans'#createにおいて、ログインしているユーザーがリーダーではなかった場合、'plans/index'にリダイレクトさせ、処理をそこで中断するように修正