### PR TITLE
しおり作成時の目的地を選択式で47都道府県を選べるように変更

### DIFF
--- a/app/assets/stylesheets/trips/new.scss
+++ b/app/assets/stylesheets/trips/new.scss
@@ -40,6 +40,11 @@
       padding: 10px;
       margin-top: 10px;
     }
+    .select-field {
+      padding: 5px;
+      width: 300px;
+      font-size: 20px;
+    }
     .calendar-field {
       font-size: 20px;
       height: 20px;

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -60,6 +60,6 @@ class TripsController < ApplicationController
   private
 
   def trips_params
-    params.require(:trip).permit(:title, :date, :distination, :spot_suggestion_limit, :spot_vote_limit, :start_time, :finish_time, :image, :created_user_id)
+    params.require(:trip).permit(:title, :date, :destination, :spot_suggestion_limit, :spot_vote_limit, :start_time, :finish_time, :image, :created_user_id)
   end
 end

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -19,6 +19,17 @@ class Trip < ApplicationRecord
   validates :start_time, presence: true
   validates :finish_time, presence: true
 
+  DESTINATION = [
+    "北海道", "青森県", "岩手県", "宮城県", "秋田県", "山形県", "福島県",
+    "茨城県", "栃木県", "群馬県", "埼玉県", "千葉県", "東京都", "神奈川県",
+    "新潟県", "富山県", "石川県", "福井県", "山梨県", "長野県",
+    "岐阜県", "静岡県", "愛知県", "三重県",
+    "滋賀県", "京都府", "大阪府", "兵庫県", "奈良県", "和歌山県",
+    "鳥取県", "島根県", "岡山県", "広島県", "山口県",
+    "徳島県", "香川県", "愛媛県", "高知県",
+    "福岡県", "佐賀県", "長崎県", "熊本県", "大分県", "宮崎県", "鹿児島県", "沖縄県"
+  ]
+
   def create_trip_user
     TripUser.create!(trip_id: id, user_id: created_user_id, is_leader: true)
   end

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -1,4 +1,14 @@
 class Trip < ApplicationRecord
+  DESTINATIONS = [
+    "北海道", "青森県", "岩手県", "宮城県", "秋田県", "山形県", "福島県",
+    "茨城県", "栃木県", "群馬県", "埼玉県", "千葉県", "東京都", "神奈川県",
+    "新潟県", "富山県", "石川県", "福井県", "山梨県", "長野県",
+    "岐阜県", "静岡県", "愛知県", "三重県",
+    "滋賀県", "京都府", "大阪府", "兵庫県", "奈良県", "和歌山県",
+    "鳥取県", "島根県", "岡山県", "広島県", "山口県",
+    "徳島県", "香川県", "愛媛県", "高知県",
+    "福岡県", "佐賀県", "長崎県", "熊本県", "大分県", "宮崎県", "鹿児島県", "沖縄県"
+  ]
   after_create :create_trip_user
 
   has_many :trip_transportations
@@ -18,17 +28,7 @@ class Trip < ApplicationRecord
   validates :spot_vote_limit, presence: true
   validates :start_time, presence: true
   validates :finish_time, presence: true
-
-  DESTINATION = [
-    "北海道", "青森県", "岩手県", "宮城県", "秋田県", "山形県", "福島県",
-    "茨城県", "栃木県", "群馬県", "埼玉県", "千葉県", "東京都", "神奈川県",
-    "新潟県", "富山県", "石川県", "福井県", "山梨県", "長野県",
-    "岐阜県", "静岡県", "愛知県", "三重県",
-    "滋賀県", "京都府", "大阪府", "兵庫県", "奈良県", "和歌山県",
-    "鳥取県", "島根県", "岡山県", "広島県", "山口県",
-    "徳島県", "香川県", "愛媛県", "高知県",
-    "福岡県", "佐賀県", "長崎県", "熊本県", "大分県", "宮崎県", "鹿児島県", "沖縄県"
-  ]
+  validates :destination, inclusion: { in: DESTINATIONS }
 
   def create_trip_user
     TripUser.create!(trip_id: id, user_id: created_user_id, is_leader: true)

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -23,7 +23,7 @@ class Trip < ApplicationRecord
 
   enum :status, { in_progress: 0, completed: 1 }
   validates :title, presence: true
-  validates :distination, presence: true
+  validates :destination, presence: true
   validates :spot_suggestion_limit, presence: true
   validates :spot_vote_limit, presence: true
   validates :start_time, presence: true

--- a/app/views/trips/new.html.erb
+++ b/app/views/trips/new.html.erb
@@ -33,7 +33,7 @@
           <%= f.label :distination, class:"form-label" %>
         </div>
       </div>
-      <%= f.select :distination, Trip::DESTINATION, { prompt: "目的地を選択してください" }, class:"select-field" %>
+      <%= f.select :distination, Trip::DESTINATIONS, { prompt: "目的地を選択してください" }, class:"select-field" %>
     </div>
     <div class="icon-required-container">
       <span class="required-button"><%= t('.required') %></span>

--- a/app/views/trips/new.html.erb
+++ b/app/views/trips/new.html.erb
@@ -33,7 +33,7 @@
           <%= f.label :distination, class:"form-label" %>
         </div>
       </div>
-      <%= f.text_field :distination, class:"text-field" %>
+      <%= f.select :distination, Trip::DESTINATION, { prompt: "目的地を選択してください" }, class:"select-field" %>
     </div>
     <div class="icon-required-container">
       <span class="required-button"><%= t('.required') %></span>

--- a/app/views/trips/new.html.erb
+++ b/app/views/trips/new.html.erb
@@ -30,10 +30,10 @@
         <span class="required-button"><%= t('.required') %></span>
         <div class="icon-label">
           <i class="fa-solid fa-plane"></i>
-          <%= f.label :distination, class:"form-label" %>
+          <%= f.label :destination, class:"form-label" %>
         </div>
       </div>
-      <%= f.select :distination, Trip::DESTINATIONS, { prompt: "目的地を選択してください" }, class:"select-field" %>
+      <%= f.select :destination, Trip::DESTINATIONS, { prompt: "目的地を選択してください" }, class:"select-field" %>
     </div>
     <div class="icon-required-container">
       <span class="required-button"><%= t('.required') %></span>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -13,7 +13,7 @@ ja:
       trip:
         title: しおりのタイトル
         date: 旅行日程
-        distination: 行き先
+        destination: 行き先
         spot_suggestion_limit: 提案の締切
         spot_vote_limit: 投票の締切
         start_time: 観光開始時間

--- a/db/migrate/20250417042938_create_trips.rb
+++ b/db/migrate/20250417042938_create_trips.rb
@@ -4,7 +4,7 @@ class CreateTrips < ActiveRecord::Migration[8.0]
       t.timestamps
       t.string :title, null: false
       t.date :date
-      t.string :distination, null: false
+      t.string :destination, null: false
       t.datetime :start_time, null: false
       t.datetime :finish_time, null: false
       t.integer :status, null: false, default: 0

--- a/db/migrate/20250612080343_add_decided_plan_id_to_trips.rb
+++ b/db/migrate/20250612080343_add_decided_plan_id_to_trips.rb
@@ -1,6 +1,5 @@
 class AddDecidedPlanIdToTrips < ActiveRecord::Migration[8.0]
   def change
-    add_column :trips, :decided_plan_id, :bigint
     add_foreign_key :trips, :plans, column: :decided_plan_id, on_update: :cascade
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -165,7 +165,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_12_080343) do
     t.datetime "updated_at", null: false
     t.string "title", null: false
     t.date "date"
-    t.string "distination", null: false
+    t.string "destination", null: false
     t.datetime "start_time", null: false
     t.datetime "finish_time", null: false
     t.integer "status", default: 0, null: false


### PR DESCRIPTION
### 概要
しおり作成を行う際の目的地入力に関して、'select_field'を用いることで47都道府県を選択できるように変更しました
写真1つ目
<img width="640" alt="スクリーンショット 2025-06-23 18 42 53" src="https://github.com/user-attachments/assets/0de47220-9374-4b8a-8064-bda053e321fe" />

写真2つ目



<img width="361" alt="スクリーンショット 2025-06-23 18 42 57" src="https://github.com/user-attachments/assets/8417d79e-f01c-4a1f-8c3a-b4fab65dc1be" />

---
### 修正内容
1. 'trip.rb'に''47都道府県を入力した配列(DESTINATION)を作成

2. 'trips/new.html'における目的地の入力形式を選択式に変更
- 'select_field'を用いて選択形式を実装(選択肢には'Trip::DESTINATION'を読み込んでいます)

3. スペルミス'distination'　→　'destination'に修正

---