### PR TITLE
'trips/new.html'のしおりタイトルの入力フォームに用いているcss 'text_field'の横幅を修正

### DIFF
--- a/app/assets/stylesheets/trips/new.scss
+++ b/app/assets/stylesheets/trips/new.scss
@@ -33,7 +33,7 @@
       font-weight: bold;
     }
     .text-field {
-      width: 100%; 
+      width: 380px; 
       height: 25px;
       border: 1px solid #ddd;
       border-radius: 4px;


### PR DESCRIPTION
### 概要
'text_field'の横幅を親要素の'card-style'を超えないように修正しました

