### PR TITLE
しおり作成時にActiveStorageに画像を保存するように変更(imageが指定されていない場合はデフォルト画像)

### DIFF
--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -1,4 +1,5 @@
 class Trip < ApplicationRecord
+  before_create :trip_image
   DESTINATIONS = [
     "北海道", "青森県", "岩手県", "宮城県", "秋田県", "山形県", "福島県",
     "茨城県", "栃木県", "群馬県", "埼玉県", "千葉県", "東京都", "神奈川県",

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  before_save :user_avatar
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/homes/_trip_card.html.erb
+++ b/app/views/homes/_trip_card.html.erb
@@ -3,7 +3,7 @@
     <div class="trip-title">
       <%= trip_card.title %>
     </div>
-    <%= image_tag trip_card.trip_image.variant(resize_to_fill: [190,130]) %>
+    <%= image_tag trip_card.image.variant(resize_to_fill: [190,130]) %>
     <div class="member">
       <%= t('homes.index.member')%>
     </div>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -3,7 +3,7 @@
     <h1 class="title"><%= t('.title')%></h1>
     <div class="image-user-data">
       <div class="image">
-        <%= image_tag current_user.user_avatar.variant(resize_to_fit: [180,180]),class:"img" %>
+        <%= image_tag current_user.avatar.variant(resize_to_fit: [180,180]),class:"img" %>
       </div>
       <div class="user-data">
         <div class="user-data-card-style">


### PR DESCRIPTION
### 概要
しおり作成時およびユーザープロフィール編集時に、画像ファイルの添付の有無に応じてActiveStorageに画像を保存する処理を追加しました。これにより画像が添付されていなくてもデフォルト画像が保存されるようになります。
### 修正内容
**1. しおり作成時の処理を変更**
コールバック関数'before_create'を用いてしおり作成時に'trip_image'メソッドが実行されるように修正

2. ユーザー編集時の処理を変更
コールバック関数'before_save'を用いてユーザー編集時に'user_image'メソッドが実行されるように修正

