### PR TITLE
プラン表示の仕組みを修正

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -6,7 +6,7 @@ class PlansController < ApplicationController
     if @trip.decided_plan_id.present?
       redirect_to trip_path(@trip)
     end
-    @elements = Plan.plans_display_data_create(plans: @plans, trip: @trip)
+    @elements = Plan.plans_display_data(plans: @plans, trip: @trip)
   end
   def create
     trip = Trip.find(params[:trip_id])
@@ -22,8 +22,7 @@ class PlansController < ApplicationController
 
     trip_max_time = trip.trip_max_time_calculation
 
-    spots_unique_numbers = params[:spot_unique_numbers]
-    spots_in_vote_order = Spot.spots_in_vote_order(spots_unique_numbers)
+    spots_in_vote_order = Spot.spots_in_vote_order(params[:spot_unique_numbers])
 
     category_ids = spots_in_vote_order.map(&:category_id)
     category_stay_time_in_vote_order = Category.category_stay_time_in_vote_order(category_ids)
@@ -54,13 +53,13 @@ class PlansController < ApplicationController
   def edit
     @trip = Trip.find(params[:trip_id])
     @plan = Plan.find(params[:id])
-    @elements = Plan.plans_display_data_create(plans: @plan, trip: @trip)
+    @elements = Plan.plans_display_data(plans: @plan, trip: @trip)
   end
 
   def update
     @plan = Plan.find(params[:id])
     @trip = @plan.trip
-    @elements = Plan.plans_display_data_create(plans: @plan, trip: @trip)
+    @elements = Plan.plans_display_data(plans: @plan, trip: @trip)
     trip_max_time = (@trip.finish_time - @trip.start_time)/Plan::SIXTY_MINUTES
     begin
       ActiveRecord::Base.transaction do

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -39,8 +39,8 @@ class TripsController < ApplicationController
     ng_spot = SpotVote.ng_spot_decided(spot_votes: spot_votes, trip_users: @trip_users)
     @voted_result = SpotSuggestion.voted_result(trip: @trip, ng_spot: ng_spot)
     @decided_plan = Plan.find_by(id: @trip.decided_plan_id)
-    if @decided_plan.present?
-      @elements = Plan.plans_display_data_create(plans: @decided_plan, trip: @trip)
+    if @decided_plan
+      @elements = Plan.plans_display_data(plans: @decided_plan, trip: @trip)
     end
   end
 

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -5,15 +5,15 @@ class Plan < ApplicationRecord
 
   SIXTY_MINUTES = 60
 
-  def self.plans_display_data_create(plans:, trip:)
+  def self.plans_display_data(plans:, trip:)
     elements = {}
     Array(plans).each do |plan|
-      plan.plan_element_create(elements)
+      plan.plan_element(elements)
     end
     elements
   end
 
-  def plan_element_create(elements)
+  def plan_element(elements)
     elements[self.id] = []
     current_time = self.trip.start_time
     plan_spots = PlanSpot.where(plan_id: self.id).index_by(&:spot_id)


### PR DESCRIPTION
### 概要
プラン表示に使用しているメソッド'Spot.plans_display_data_create(plans:, trip:)'と'plan_element_create(elements)'のメソッド名から'create'を削除しました。
これによりDBへの保存処理と混同することがなくなります