### PR TITLE
ヘッダーの作成

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -25,3 +25,4 @@
 @use "shared/plan.scss" as shared_plan;
 @use "plans/edit.scss" as plans_edit;
 @use "pages/index.scss" as pages_index;
+@use "shared/header.scss" as shared_header;

--- a/app/assets/stylesheets/homes/index.scss
+++ b/app/assets/stylesheets/homes/index.scss
@@ -1,7 +1,7 @@
 .homes-index {
   .card-style {
     margin: 0 auto;
-    margin-top: 50px;
+    margin-top: 100px;
     margin-bottom: 100px;
     width: 600px;
     border: 1px solid #ddd;

--- a/app/assets/stylesheets/shared/flash_messages.scss
+++ b/app/assets/stylesheets/shared/flash_messages.scss
@@ -1,4 +1,5 @@
 .shared-flash-messages {
+  margin-top: 65px;
   .flash-success {
     background-color: #d4edda;
     padding: 7.5px 12.5px;

--- a/app/assets/stylesheets/shared/header.scss
+++ b/app/assets/stylesheets/shared/header.scss
@@ -1,0 +1,27 @@
+.shared-header {
+  display: flex;
+  position: fixed; top: 0;
+  width: 100%;
+  height: 60px;
+  border-bottom: 2px solid #ccc;
+  background-color: #ffffff;
+  z-index: 100;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08); 
+  .header-left {
+    font-size: 25px;
+    font-weight: bold;
+    margin-right: auto;
+    padding: 15px;
+  }
+  .header-right {
+    font-size: 20px;
+    display: flex;
+    gap: 20px;
+    margin-left: auto;
+    padding: 15px;
+  }
+  .link {
+   text-decoration: none;
+   color: #1a73e8;
+ }
+}

--- a/app/assets/stylesheets/spots/show.scss
+++ b/app/assets/stylesheets/spots/show.scss
@@ -1,7 +1,7 @@
 .spots-show {
   .card-style {
     margin: 0 auto;
-    margin-top: 50px;
+    margin-top: 100px;
     width: 600px;
     border: 1px solid #ddd;
     border-radius: 8px;

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -58,5 +58,3 @@
     </div>
   </div>
 </div>
-
-<%= link_to t('.logout'), destroy_user_session_path, method: :delete, data: { confirm: "本当に削除しますか？" }%>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,6 +28,9 @@
   </head>
 
   <body>
+    <% unless controller_name == 'pages' && action_name == 'index' %>
+      <%= render "shared/header"%>
+    <% end %>
     <%= render "shared/flash_messages"%>
     <%= yield %>
   </body>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,0 +1,15 @@
+<div class="shared-header">
+  <div class="header-left">
+    <%= link_to "TabiNote", root_path, class: "link" %>
+  </div>
+  <div class="header-right">
+    <% if user_signed_in? %>
+      <%= link_to "マイページ", homes_path, class: "link" %>
+      <%= link_to "しおり作成", new_trip_path, class: "link" %>
+      <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { confirm: "本当にログアウトしますか？" }, class: "link" %>
+    <% else %>
+      <%= link_to "ログイン", new_user_session_path, class: "link" %>
+      <%= link_to "サインアップ", new_user_registration_path, class: "link" %>
+    <% end %>
+  </div>
+</div>


### PR DESCRIPTION
### 概要
各ページの上部に固定して表示されるヘッダーを作成しました
ヘッダーの中身は以下になります
**ログイン時**
- LPへの遷移リンク(root_path)
- マイページへの遷移リンク(homes_path)
- ログアウトリンク(destroy_user_session_path)

**未ログイン時**
-  LPへの遷移リンク(root_path)
- ログイン画面への遷移リンク(new_user_session_path)
- 新規登録画面への遷移リンク(new_user_registration_path)

※LPではヘッダーが表示されないようにしています

レイアウトは以下になります
<img width="1440" alt="スクリーンショット 2025-06-25 12 49 02" src="https://github.com/user-attachments/assets/e511b43e-111d-48aa-969c-f0b3dd0ccccf" />
