### PR TITLE
幹事以外はプランの編集ができないように修正

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -1,4 +1,5 @@
 class PlansController < ApplicationController
+  before_action :current_user_leader?, only: [ :edit, :update ]
   def index
     @trip = Trip.find(params[:trip_id])
     @plans = @trip.plans
@@ -87,6 +88,14 @@ class PlansController < ApplicationController
       Rails.logger.error "編集処理でエラー発生: #{e.class} - #{e.message}"
       flash.now[:alert] = "プランを更新することができませんでした"
       render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def current_user_leader?
+    trip = Trip.find(params[:trip_id])
+    unless TripUser.current_user_is_leader?(trip: trip, current_user: current_user)
+      flash[:alert] = "プランの編集画面にアクセスする権限がありません"
+      redirect_to homes_path
     end
   end
 

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -42,6 +42,7 @@ class TripsController < ApplicationController
     if @decided_plan
       @elements = Plan.plans_display_data(plans: @decided_plan, trip: @trip)
     end
+    @current_user_is_leader = TripUser.current_user_is_leader?(trip: @trip, current_user: current_user)
   end
 
   def suggestion

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -2,7 +2,7 @@
   <div class="card-style">
     <%= render "shared/trip_data", trip: @trip %>
     <% if @trip.decided_plan_id.present? %>
-      <%= render "shared/plan", trip: @trip, spots: @decided_plan.spots, plan: @decided_plan, plan_create: false, elements: @elements[@decided_plan.id], edit_icon: true %>
+      <%= render "shared/plan", trip: @trip, spots: @decided_plan.spots, plan: @decided_plan, plan_create: false, elements: @elements[@decided_plan.id], edit_icon: @current_user_is_leader %>
     <% else %>
       <turbo-frame id="phase">
         <% if @trip.within_spot_vote_limit_date? %>


### PR DESCRIPTION
### 概要
以下の2つを実装しました
1. しおり詳細ページにおいて、プランを表示する際にログインしているユーザーが幹事の時にしか編集アイコンが表示されないように修正

2. plansコントローラにおいて、#editと#updateを実行する前に現在ログインしているユーザーが幹事かどうかを確認する仕組みを実装

---
### 修正内容
1. ログインしているユーザーが幹事の時のみ編集アイコンを表示
- インスタンス変数(@current_user_leader?)を作成 : ログインしているユーザーが幹事なら'true'メンバーなら'false'を格納
- ビューで@current_user_leader?が'true'なら編集アイコンを表示し、'false'なら表示しない

2. plans #edit #updateを実行する前にログインしているユーザーが幹事かどうかを判定
-  plansにログインしているユーザーが幹事かどうかを判定するメソッドを作成 : 'current_user_leader?'
- コールバック関数(before_action)を用いて#editと#updateを実行する前に'current_user_leader?'が実行されるように変更

---