### PR TITLE
招待リンククリック後、新規登録を行った場合しおりに参加することができないエラーを修正

### DIFF
--- a/app/controllers/trip_users_controller.rb
+++ b/app/controllers/trip_users_controller.rb
@@ -1,5 +1,4 @@
 class TripUsersController < ApplicationController
-  before_action :store_location, only: [ :join_page ]
   skip_before_action :authenticate_user!, only: [ :join_page ]
 
   def index
@@ -42,9 +41,5 @@ class TripUsersController < ApplicationController
       flash[:alert] = "退会できませんでした"
       redirect_back fallback_location: homes_path
     end
-  end
-
-  def store_location
-    store_location_for(:user, request.fullpath)
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -53,7 +53,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # The path used after sign up.
   def after_sign_up_path_for(resource)
-    homes_path
+    stored_location_for(resource) || homes_path
   end
 
   def after_update_path_for(resource)


### PR DESCRIPTION
### 概要
未ログイン状態で招待リンクをクリックしたユーザーが、そのまま新規登録を行った場合でも、登録完了後に「しおり参加ページ」へリダイレクトされるように修正しました

'ApplicationController'ではなく'Users::RegistrationsController'に以下のように'after_sign_up_path_for'を定義し、Deviseのリダイレクト処理をカスタマイズしています。
```
  def after_sign_up_path_for(resource)
    stored_location_for(resource) || homes_path
  end
```