### PR TITLE
スマホで開く際のマイページのサイズを修正

### DIFF
--- a/app/assets/stylesheets/homes/index.scss
+++ b/app/assets/stylesheets/homes/index.scss
@@ -151,6 +151,8 @@
 @media (max-width: 768px) {
   .homes-index {
     .card-style {
+      width: 90%;
+      margin: 0 auto;
       padding: 1rem;
       .image-user-data {
         flex-direction: column;

--- a/app/views/homes/_trip_card.html.erb
+++ b/app/views/homes/_trip_card.html.erb
@@ -3,7 +3,7 @@
     <div class="trip-title">
       <%= trip_card.title %>
     </div>
-    <%= image_tag trip_card.image.variant(resize_to_fill: [192,130]),  class: "trip-image" %>
+    <%= image_tag trip_card.image, class: "trip-image" %>
     <div class="member">
       <%= t('homes.index.member')%>
     </div>


### PR DESCRIPTION
### 概要
スマホで開く際の画面において、以下の修正を行いました
- 画像サイズの修正 : variant(resize_to_fill: [192,130])を削除
- card-styleのサイズ修正 : レスポンシブの際のサイズをwidth: 90%に変更

