### PR TITLE
ヘッダーをレスポンシブ対応

### DIFF
--- a/app/assets/stylesheets/shared/header.scss
+++ b/app/assets/stylesheets/shared/header.scss
@@ -2,26 +2,46 @@
   display: flex;
   position: fixed; top: 0;
   width: 100%;
-  height: 60px;
-  border-bottom: 2px solid #ccc;
+  height: 3.75rem;
+  border-bottom: 0.125rem solid #ccc;
   background-color: #ffffff;
   z-index: 100;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08); 
+  box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.08); 
   .header-left {
-    font-size: 25px;
+    font-size: 1.6rem;
     font-weight: bold;
     margin-right: auto;
-    padding: 15px;
+    padding: 1rem;
   }
   .header-right {
-    font-size: 20px;
+    font-size: 1.25rem;
     display: flex;
-    gap: 20px;
+    gap: 1.25rem;
     margin-left: auto;
-    padding: 15px;
+    padding: 1rem;
   }
   .link {
     text-decoration: none;
     color: #1a73e8;
+  }
+}
+@media (max-width: 768px) {
+  .shared-header {
+    height: auto;
+    align-items: center;
+    text-align: center;
+    padding: 0.5rem;
+
+    .header-left {
+      font-size: 1.25rem;
+      padding: 0.6rem;
+    }
+
+    .header-right {
+      gap: 0.6rem;
+      font-size: 1rem;
+      padding: 0.6rem 1.5rem 0.6rem 0.6rem;
+      flex-wrap: wrap;
+    }
   }
 }


### PR DESCRIPTION
### 概要
ヘッダーがスマホ画面でも適切に表示されるようにレスポンシブ対応を実装しました(max-width: 768px)

以下レイアウトになります
<img width="560" alt="スクリーンショット 2025-06-26 9 41 17" src="https://github.com/user-attachments/assets/7cccff69-14d7-454a-83bd-27d140fa9225" />
