### PR TITLE
しおり詳細ページをレスポンシブ対応

### DIFF
--- a/app/assets/stylesheets/trips/show.scss
+++ b/app/assets/stylesheets/trips/show.scss
@@ -1,30 +1,30 @@
 .trips-show {
   .card-style {
     margin: 0 auto;
-    margin-top: 100px;
-    margin-bottom: 100px;
-    width: 600px;
+    margin-top: 6.25rem;
+    margin-bottom: 6.25rem;
+    width: 37.5rem;
     border: 1px solid #ddd;
     border-radius: 8px;
     box-shadow: 0 4px 9px rgba(0, 0, 0, 0.1);
     .label-container {
       display: flex;
       text-align: center;
-      width: 500px;
+      width: 31rem;
       margin: auto;
-      margin-top: 70px;
+      margin-top: 4.4rem;
       .suggestion-vote-link {
         border: 1px solid black;
-        width: 250px;
+        width: 15.6rem;
       }
       .suggestion-vote-hilight-link {
         background-color: #99FFFF;
         border: 1px solid black;
-        width: 250px;
+        width: 15.6rem;
       }
       .suggestion-vote-link a,
       .suggestion-vote-hilight-link a {
-        font-size: 20px;
+        font-size: 1.25rem;
         font-weight: bold;
         color: inherit;
         text-decoration: none;
@@ -32,22 +32,22 @@
     }
     .suggestion-vote-container {
       display: flex;
-      width: 500px;
+      width: 31rem;
       margin: auto;
       .suggestion-vote-card-style {
-        width: 500px;
+        width: 31rem;
         border: 1px solid black;
         .suggestion-vote-limit {
-          margin-top: 30px;
-          margin-bottom: 30px;
+          margin-top: 1.9rem;
+          margin-bottom: 1.9rem;
           color: red;
           text-align: center;
-          font-size: 30px;
+          font-size: 1.9rem;
         }
         .spot-suggestion-vote-headline {
-          margin-top: 30px;
+          margin-top: 1.9rem;
           text-align: center;
-          font-size: 30px;
+          font-size: 1.9rem;
           font-weight: bold;
         }
         .ng-vote-description {
@@ -57,38 +57,38 @@
         }
         .voted-spot-title {
           text-align: center;
-          margin-top: 30px;
-          margin-bottom: 30px;
-          font-size: 30px;
+          margin-top: 1.9rem;
+          margin-bottom: 1.9rem;
+          font-size: 1.9rem;
           font-weight: bold;
         }
         .vote-result-title {
           text-align: center;
-          margin-top: 20px;
-          margin-bottom: 20px;
+          margin-top: 1,25rem;
+          margin-bottom: 1.25rem;
           color: red;
-          font-size: 35px;
+          font-size: 2.2rem;
           font-weight: bold;
         }
         .vote-result-headline {
           text-align: center;
-          margin-bottom: 30px;
-          font-size: 25px;
+          margin-bottom: 1.9rem;
+          font-size: 1.6rem;
           font-weight: bold;
         }
         .spot-card-style {
           border: 1px solid black;
-          margin-bottom: 30px;
+          margin-bottom: 1.9rem;
         }
         .spot-image-container {
           display: flex;
           white-space: nowrap;
           flex-wrap: wrap;
-          width: 500px;
+          width: 31rem;
           justify-content: center;
-          margin-top: 30px;
-          margin-bottom: 30px;
-          gap: 20px;
+          margin-top: 1.9rem;
+          margin-bottom: 1.9rem;
+          gap: 1.25rem;
           .already-vote-spot-image {
             .already-voted {
               text-align: center;
@@ -96,17 +96,17 @@
             }
             .spot-image {
               border: 1px solid black;
-              padding: 10px;
-              width: 120px;
+              padding: 0.6rem;
+              width: 7.5rem;
               text-align: center;
               .image {
                 display: block;
-                width: 120px;
-                height: 120px;
+                width: 7.5rem;
+                height: 7.5rem;
               }
               .spot-delete-link {
                 text-decoration: none;
-                font-size: 10px;
+                font-size: 0.6rem;
                 color: red;
               }
             }
@@ -114,10 +114,10 @@
         }
         .submit-form {
           text-align: center;
-          margin-top: 20px;
-          margin-bottom: 30px;
+          margin-top: 1.25rem;
+          margin-bottom: 1.9rem;
           .submit-button {
-            font-size: 20px;
+            font-size: 1.25rem;
             background-color: #007bff;
             color: white;
             border: 1px solid #007bff;
@@ -127,20 +127,20 @@
         }
         .not-voted-spot {
           text-align: center;
-          font-size: 20px;
-          margin-bottom: 50px;
+          font-size: 1.25rem;
+          margin-bottom: 3.1rem;
         }
         .no-spot-suggestion-vote-headline {
-          margin-top: 100px;
-          margin-bottom: 100px;
+          margin-top: 6.25rem;
+          margin-bottom: 6.25rem;
           text-align: center;
-          font-size: 20px;
+          font-size: 1.25rem;
         }
         .spot-add-container {
           display: flex;
           justify-content: right;
-          gap: 5px;
-          padding: 10px;
+          gap: 0.3rem;
+          padding: 0.6rem;
           .spot-add {
             color: blue;
           }
@@ -148,44 +148,44 @@
       }
     }
     .member-container {
-      margin-top: 50px;
+      margin-top: 3.1rem;
       display: flex;
       justify-content: center;
-      margin-bottom: 100px;
+      margin-bottom: 6.25rem;
       .member-card-style {
-        width: 300px;
+        width: 18.8rem;
         border: 1px solid black;
         border-radius: 8px;
-        padding: 10px;
+        padding: 0.6rem;
         .member-title {
           text-align: center;
-          font-size: 25px;
+          font-size: 1.6rem;
           font-weight: bold;
-          margin-bottom: 10px;
+          margin-bottom: 0.6rem;
         }
         .member-list {
-          font-size: 20px;
-          margin-left: 50px;
+          font-size: 1.25rem;
+          margin-left: 3.1rem;
           display: flex;
           align-items: center;
-          width: 270px;
-          gap: 10px;
+          width: 16.9rem;
+          gap: 0.6rem;
           .crown-icon {
             color: yellow;
-            width: 20px;
+            width: 1.25rem;
             text-align: center;
             display: inline-block;
             flex-shrink: 0;
           }
           .current-user-icon {
-            width: 20px;
+            width: 1.25rem;
             text-align: center;
             display: inline-block;
             flex-shrink: 0;
             color: blue;
           }
           .user-icon {
-            width: 20px;
+            width: 1.25rem;
             text-align: center;
             display: inline-block;
             flex-shrink: 0;
@@ -193,8 +193,8 @@
         }
         .member-edit-link {
           text-align: right;
-          margin-top: 20px;
-          font-size: 13px;
+          margin-top: 1.25rem;
+          font-size: 0.8rem;
           .member-edit {
             color: blue;
           }


### PR DESCRIPTION
### 概要
しおり詳細ページがスマホでも適切に表示されるよう、主にサイズ指定を px から rem に変更しました。
※横並びなどの構造は維持したまま、縮小表示されるように調整しています。

以下レイアウトになります
<img width="387" alt="スクリーンショット 2025-06-26 10 26 29" src="https://github.com/user-attachments/assets/128422a9-8cad-4a2a-9614-03e400f7d98b" />
<img width="384" alt="スクリーンショット 2025-06-26 10 26 41" src="https://github.com/user-attachments/assets/f92dc7d8-76a1-4fb8-93ce-724f5ef4f125" />
