### PR TITLE
しおり詳細ページにおいてレスポンシブ対応できていなかった箇所を修正

### DIFF
--- a/app/assets/stylesheets/shared/trip_data.scss
+++ b/app/assets/stylesheets/shared/trip_data.scss
@@ -1,28 +1,28 @@
 .title {
   text-align: center;
-  gap: 20px;
-  font-size: 30px;
-  margin-top: 30px;
-  margin-bottom: 30px;
+  gap: 1.25rem;
+  font-size: 1.9rem;
+  margin-top: 1.9rem;
+  margin-bottom: 1.9rem;
 }
 .trip-detail-container {
-  margin-bottom: 50px;
+  width: 100%;
+  max-width: 37.5rem;
+  margin-bottom: 3.1rem;
   .trip-detail {
-    width: 300px;
-    margin-bottom: 20px;
-    font-size: 20px;
+    width: 100%;
+    max-width: 18.8rem;
+    margin-bottom: 1.25rem;
+    font-size: 1.25rem;
     margin: 0 auto;
     .icon-label {
       display: flex;
       align-items: center;
-      gap: 10px;
+      gap: 0.6rem;
     }
     .trip-info {
-      display: flex;
-      align-items: center;
-      padding: 10px;
-      width: 300px;
-      height: 40px;
+      padding: 0.6rem;
+      line-height: 2.5rem;
       border: 1px solid #ddd;
       border-radius: 8px;
       box-shadow: 0 4px 9px rgba(0, 0, 0, 0.1);

--- a/app/assets/stylesheets/trips/show.scss
+++ b/app/assets/stylesheets/trips/show.scss
@@ -3,14 +3,16 @@
     margin: 0 auto;
     margin-top: 6.25rem;
     margin-bottom: 6.25rem;
-    width: 37.5rem;
+    width: 100%;
+    max-width: 37.5rem;
     border: 1px solid #ddd;
     border-radius: 8px;
     box-shadow: 0 4px 9px rgba(0, 0, 0, 0.1);
     .label-container {
       display: flex;
       text-align: center;
-      width: 31rem;
+      width: 100%;
+      max-width: 31rem;
       margin: auto;
       margin-top: 4.4rem;
       .suggestion-vote-link {
@@ -32,10 +34,12 @@
     }
     .suggestion-vote-container {
       display: flex;
-      width: 31rem;
+      width: 100%;
+      max-width: 31rem;
       margin: auto;
       .suggestion-vote-card-style {
-        width: 31rem;
+        width: 100%;
+        max-width: 31rem;
         border: 1px solid black;
         .suggestion-vote-limit {
           margin-top: 1.9rem;
@@ -84,7 +88,8 @@
           display: flex;
           white-space: nowrap;
           flex-wrap: wrap;
-          width: 31rem;
+          width: 100%;
+          max-width: 31rem;
           justify-content: center;
           margin-top: 1.9rem;
           margin-bottom: 1.9rem;
@@ -202,9 +207,11 @@
       }
     }
     .join-trip {
+      padding: 0.5rem;
       text-align: center;
       margin-bottom: 1.9rem;
       font-size: 1.25rem;
+      overflow-wrap: break-word;
     }
   }
 }


### PR DESCRIPTION
### 概要
しおり詳細ページをスマホで表示した際に、'shared/trip_data'の箇所やスポット画像の表示箇所が一部うまく表示されていなかったため修正しました

レイアウトは以下になります
<img width="362" alt="スクリーンショット 2025-06-26 11 24 35" src="https://github.com/user-attachments/assets/85d0924b-368f-4c5c-8a7e-551bf5674cca" />
<img width="391" alt="スクリーンショット 2025-06-26 11 24 42" src="https://github.com/user-attachments/assets/217b7cde-020a-4dc1-8475-3f38a59f9882" />
<img width="342" alt="スクリーンショット 2025-06-26 11 22 11" src="https://github.com/user-attachments/assets/22e632c4-ebd5-4cc6-8061-18607181dcab" />
