### PR TITLE
lpをレスポンシブ対応

### DIFF
--- a/app/assets/stylesheets/pages/index.scss
+++ b/app/assets/stylesheets/pages/index.scss
@@ -1,25 +1,26 @@
 .lp {
   .header {
+    width: 100%;
     color: #ffffff;
     text-shadow: 0 2px 4px rgba(0, 0, 0, 0.6);
-    padding: 20px;
+    padding: 1.25rem;
     background: url("/images/lp_image.jpg") no-repeat center center;
     background-size: cover;
     text-align: center;
-    padding: 80px 20px;
-    font-size: 20px;
+    padding: 5rem 1.25rem;
+    font-size: 1.25rem;
     .title {
-      font-size: 40px;
-      margin-bottom: 16px;
+      font-size: 2.5rem;
+      margin-bottom: 1rem;
     }
     .sub-title {
-      font-size: 20px;
-      margin-bottom: 8px;
+      font-size: 1.25rem;
+      margin-bottom: 0.5rem;
     }
-   
+
     .button {
       display: inline-block;
-      padding: 10px 20px;
+      padding: 0.5rem 1.25rem;
       background-color: #2563eb;
       color: #fff;
       border-radius: 5px;
@@ -30,43 +31,84 @@
     }
   }
   .group {
-    font-size: 20px;
-    padding: 30px 20px;
-    width: 1000px;
+    font-size: 1.25rem;
+    padding: 1.9rem 1.25rem;
+    width: 100%;
+    max-width: 62.5rem;
     margin: 0 auto;
     .group-title {
-      font-size: 24px;
+      font-size: 1.5rem;
       border-bottom: 1px solid #ccc;
-      margin-bottom: 30px;
-      padding-bottom: 8px;
+      margin-bottom: 1.9rem;
+      padding-bottom: 0.5rem;
       color: #1a73e8;
     }
     .conclusion {
-      font-size: 25px;
+      font-size: 1.6rem;
       line-height: 1.8;
-      margin-top: 40px;
+      margin-top: 2.5rem;
     }
     .image-grid {
       display: flex;
       flex-wrap: wrap;
-      gap: 16px;
+      gap: 1rem;
       justify-content: center;
       .image-container {
-         text-align: center;
+        text-align: center;
         .image-title {
-         font-weight: bold;
+        font-weight: bold;
         }
       }
+    }
+    .github-link {
+      overflow-wrap: break-word;
     }
 
     .image-grid img {
       width: 100%;
-      max-width: 400px;
+      max-width: 25rem;
       border-radius: 8px;
       box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-     }
+    }
     ul {
-     line-height: 3;
+      line-height: 3;
+    }
+  }
+}
+@media (max-width: 768px) {
+  .lp {
+    .header {
+      padding: 3rem 1rem;
+      .title {
+        font-size: 2rem;
+      }
+      .sub-title {
+        font-size: 1rem;
+      }
+      .button {
+        font-size: 1rem;
+        padding: 0.4rem 1rem;
+      }
+    }
+    .group {
+      padding: 1.5rem 1rem;
+      .group-title {
+        font-size: 1.3rem;
+      }
+      .conclusion {
+        font-size: 1.2rem;
+      }
+      .image-grid {
+        flex-direction: column;
+        align-items: center;
+        .image-container img {
+          max-width: 100%;
+        }
+      }
+      ul {
+        font-size: 1rem;
+        line-height: 2;
+      }
     }
   }
 }

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -90,7 +90,7 @@
 
   <div class="group">
     <h2 class="group-title"> GitHub / テストユーザー</h2>
-    <p>GitHub: <%= link_to "https://github.com/yusuke00001/TabiNote", "https://github.com/yusuke00001/TabiNote", target: "_blank" %></p>
+    <p class="github-link">GitHub: <%= link_to "https://github.com/yusuke00001/TabiNote", "https://github.com/yusuke00001/TabiNote", target: "_blank" %></p>
     <ul>
       <li>メールアドレス: player@1 </li>
       <li>パスワード: 123456 </li>


### PR DESCRIPTION
### 概要
スマホでLpを表示した際に、レイアウトが崩れないようにレスポンシブ対応を実装しました

以下レイアウトになります
<img width="401" alt="スクリーンショット 2025-06-26 12 05 08" src="https://github.com/user-attachments/assets/75341197-3c9c-442b-a62c-9ce00514d6d1" />
<img width="406" alt="スクリーンショット 2025-06-26 12 05 31" src="https://github.com/user-attachments/assets/0fa07117-2550-47ab-984f-b1100430c305" />
<img width="401" alt="スクリーンショット 2025-06-26 12 05 41" src="https://github.com/user-attachments/assets/f9f20103-c6f7-4521-8764-dac5a00bebc9" />
<img width="397" alt="スクリーンショット 2025-06-26 12 05 48" src="https://github.com/user-attachments/assets/31e99be1-d972-475d-9e83-d9d4a33e59fa" />
<img width="397" alt="スクリーンショット 2025-06-26 12 05 56" src="https://github.com/user-attachments/assets/3849b429-e143-4a2c-9500-fd9939b468e2" />
<img width="396" alt="スクリーンショット 2025-06-26 12 06 03" src="https://github.com/user-attachments/assets/a2d70221-0d99-4f1a-84cd-d8c00d34b67f" />
<img width="403" alt="スクリーンショット 2025-06-26 12 06 11" src="https://github.com/user-attachments/assets/23d8cbd9-7dbe-43e4-bfad-f4b6ac0dcccf" />
<img width="400" alt="スクリーンショット 2025-06-26 12 06 27" src="https://github.com/user-attachments/assets/0afe7597-654a-49eb-a8a8-1d06f904d5d0" />
<img width="395" alt="スクリーンショット 2025-06-26 12 06 33" src="https://github.com/user-attachments/assets/1fa1831a-ca87-48ae-9d4e-1ea288c70a8c" />
