### PR TITLE
スポット詳細ページをレスポンシブ対応

### DIFF
--- a/app/assets/stylesheets/spots/show.scss
+++ b/app/assets/stylesheets/spots/show.scss
@@ -1,62 +1,83 @@
 .spots-show {
   .card-style {
     margin: 0 auto;
-    margin-top: 100px;
-    width: 600px;
+    margin-top: 6.25rem;
+    width: 90%;
+    max-width: 37.5rem;
     border: 1px solid #ddd;
     border-radius: 8px;
     box-shadow: 0 4px 9px rgba(0,0,0,0.1);
     .title {
       text-align: center;
-      margin-top: 10px;
-      margin-bottom: 30px;
-      font-size: 40px;
+      margin-top: 0.6rem;
+      margin-bottom: 1.9rem;
+      font-size: 2.5rem;
       border-bottom: 1px solid #ddd;
     }
     .image {
       text-align: center;
-      margin-bottom: 20px;
+      margin-bottom: 1.25rem;
     }
     .image-size {
-      width: 200px;
-      height: 200px;
+      width: 12.5rem;
+      height: 12.5rem;
     }
     .spot-group {
       display: flex;
       align-items: center;
       border-top: 1px solid #ddd;
-      padding: 20px;
+      padding: 1.25rem;
       .label {
-        width: 150px;
-        font-size: 20px;
+        width: 9.4rem;
+        font-size: clamp(1rem, 2.5vw, 1.5rem);
       }
       .body {
         word-break: break-all;
-        width: 400px;
-        margin-left: 20px;
-        font-size: 15px;
+        width: 25rem;
+        margin-left: 1.25rem;
+        font-size: 0.9rem;
       }
     }
   }
   .search_page_link {
-    width: 600px;
+    width: 100%;
     margin: 0 auto;
-    margin-top: 20px;
+    margin-top: 1.25rem;
+    margin-bottom: 1rem;
     text-align: right;
   }
   .spot-submit {
-    width: 600px;
+    width: 100%;
     margin: 0 auto;
     text-align: center;
   }
   .submit-botton {
-   background-color: #007bff;
-   color: #fff;
-   border: none;
-   padding: 10px 20px;
-   font-size: 20px;
-   border-radius: 8px;
-   margin-bottom: 100px;
-   cursor: pointer;
+    background-color: #007bff;
+    color: #fff;
+    border: none;
+    padding: 0.6rempx 1.25rem;
+    font-size: 1.25rem;
+    border-radius: 8px;
+    margin-bottom: 6.3rem;
+    cursor: pointer;
+  }
+}
+@media (max-width: 768px) {
+  .spots-show {
+    .card-style {
+      .spot-group {
+        flex-direction: column;
+        align-items: flex-start;
+        .label {
+          width: 9.4rem;
+          font-size: 1.5rem;
+          font-weight: bold;
+        }
+        .body {
+          width: 90%;
+          font-size: 0.9rem;
+        }
+      }
+    }
   }
 }

--- a/app/assets/stylesheets/trips/show.scss
+++ b/app/assets/stylesheets/trips/show.scss
@@ -3,7 +3,7 @@
     margin: 0 auto;
     margin-top: 6.25rem;
     margin-bottom: 6.25rem;
-    width: 100%;
+    width: 90%;
     max-width: 37.5rem;
     border: 1px solid #ddd;
     border-radius: 8px;


### PR DESCRIPTION
### 概要
スマホからスポット詳細ページを開いた際に、適切なレイアウトが表示されるようにサイズ指定をpxからremに変更しました
また、画面サイズが768px以下の場合'spot-group'の中身を縦に積み重ねて表示するように変更しております

以下レイアウトになります
<img width="533" alt="スクリーンショット 2025-06-26 14 38 57" src="https://github.com/user-attachments/assets/21657244-e209-4cc6-b94a-a7af95c7d5f6" />
<img width="531" alt="スクリーンショット 2025-06-26 14 39 15" src="https://github.com/user-attachments/assets/868bb9ab-bf1a-4e59-a471-8ce9b3804b87" />
<img width="508" alt="スクリーンショット 2025-06-26 14 39 21" src="https://github.com/user-attachments/assets/a41745c7-a886-44a7-a295-ecb75e7646bc" />
