### PR TITLE
スポット詳細ページのリンク「前のページに戻る」の位置を修正

### DIFF
--- a/app/assets/stylesheets/spots/show.scss
+++ b/app/assets/stylesheets/spots/show.scss
@@ -40,7 +40,8 @@
     }
   }
   .search_page_link {
-    width: 100%;
+    width: 90%;
+    max-width: 37.5rem;
     margin: 0 auto;
     margin-top: 1.25rem;
     margin-bottom: 1rem;


### PR DESCRIPTION
### 概要
スポット詳細ページ下部の「前のページに戻る」リンクの幅を'card-style'と揃えました。
これにより、リンクが常に'card-style'の右端に揃って表示されるようになります。
