### PR TITLE
新規登録画面におけるレスポンシブ対応

### DIFF
--- a/app/assets/stylesheets/users/registrations/new.scss
+++ b/app/assets/stylesheets/users/registrations/new.scss
@@ -4,27 +4,28 @@
   }
   .card-style {
     margin: 0 auto;
-    margin-top: 100px;
-    padding: 20px;
-    width: 400px;
+    margin-top: 6.3rem;
+    padding: 1.25rem;
+    max-width: 25rem;
+    width: 85%;
     border: 1px solid #ddd;
     border-radius: 8px;
     box-shadow: 0 4px 9px rgba(0,0,0,0.1);
     .form-group {
-      margin-bottom: 30px;
+      margin-bottom: 1.9rem;
     }
     .text-field {
-      width: 100%; 
-      height: 35px;
+      width: 90%; 
+      line-height: 1.5;
       border: 1px solid #ddd;
       border-radius: 4px;
-      padding: 1px;
+      padding: 0.5rem;
     }
     .submit {
       text-align: center;
     }
     .submit-button {
-      font-size: 20px;
+      font-size: 1.25rem;
       background-color: #007bff;
       color: white;
       border: 1px solid #007bff;
@@ -32,7 +33,7 @@
     }
     .link {
       text-align: center;
-      margin-top: 10px;
+      margin-top: 0.6rem;
     }
   }
 }

--- a/app/assets/stylesheets/users/sessions/new.scss
+++ b/app/assets/stylesheets/users/sessions/new.scss
@@ -3,7 +3,7 @@
     margin: 0 auto;
     margin-top: 6.3rem;
     padding: 1.25rem;
-    width: 90%;
+    width: 85%;
     max-width: 25rem;
     border: 1px solid #ddd;
     border-radius: 8px;


### PR DESCRIPTION
### 概要
スマホから新規登録画面を開いた際にレイアウトが適切に表示されるようにサイズ指定をpxからremに変更しました。
また'card-style'の横幅を'max-width: 25rem' 'width: 85%;'とすることで画面サイズに合わせて'width'が調整されるように修正しました

※ログイン画面における'card-style'も新規登録画面と同様'width: 85%'に変更しております。

以下レイアウトになります

<img width="378" alt="スクリーンショット 2025-06-27 11 14 02" src="https://github.com/user-attachments/assets/54a36906-230d-46df-925c-9e040235aaea" />
