### PR TITLE
プラン作成画面をレスポンシブ対応

### DIFF
--- a/app/assets/stylesheets/plans/index.scss
+++ b/app/assets/stylesheets/plans/index.scss
@@ -1,35 +1,38 @@
 .plans-index {
   .card-style {
     margin: 0 auto;
-    margin-top: 100px;
-    margin-bottom: 100px;
-    width: 800px;
+    margin-top: 6.3rem;
+    margin-bottom: 6.3rem;
+    width: 90%;
+    max-width: 50rem;
     border: 1px solid #ddd;
     border-radius: 8px;
     box-shadow: 0 4px 9px rgba(0, 0, 0, 0.1);
-    padding-bottom: 10px;
+    padding-bottom: 0.6rem;
     text-align: center;
     .created-plan {
       text-align: center;
-      font-size: 30px;
+      font-size: 1.9rem;
     }
     .plans-container {
       display: flex;
       overflow-x: auto;
-      gap: 50px;
+      gap: 3.1rem;
       scroll-snap-type: x mandatory;
-      width: 580px;
+      width: 90%;
+      max-width: 36.2rem;
       margin: 0 auto;
     }
     .decided-form {
-      width: 400px;
+      width: 90%;
+      max-width: 25rem;
       margin: 0 auto;
-      margin-top: 50px;
-      margin-bottom: 50px;
+      margin-top: 3.1rem;
+      margin-bottom: 3.1rem;
     }
     .decided-button {
-      padding: 10px;
-      font-size: 25px;
+      padding: 0.6rem;
+      font-size: 1.6rem;
       font-weight: bold;
       color: white;
       background-color: #007bff;
@@ -38,13 +41,13 @@
       cursor: pointer;
     }
     .wait {
-      font-size: 40px;
-      margin-bottom: 50px;
+      font-size: 2.5rem;
+      margin-bottom: 3.1rem;
       font-weight: bold;
     }
     .wait-detail {
-      font-size: 30px;
-      margin-bottom: 100px;
+      font-size: 1.9rem;
+      margin-bottom: 6.3rem;
     }
   }
 }

--- a/app/assets/stylesheets/shared/plan.scss
+++ b/app/assets/stylesheets/shared/plan.scss
@@ -1,16 +1,17 @@
 .plan-container {
   margin: 0 auto;
   p {
-    font-size: 25px;
+    font-size: 1.6rem;
     font-weight: bold;
-    padding-top: 10px;
+    padding-top: 0.6rem;
   } 
   position: relative;
   border:1px solid black;
   border-radius: 5px;
   scroll-snap-align: start;
-  width: 550px;
-  padding: 10px;
+  max-width: 34.4rem;
+  width: 90%;
+  padding: 0.6rem;
   text-align: center;
     .selected {
     display: none;
@@ -21,12 +22,13 @@
       position: absolute;
       top: 0;
       left: 0;
-      width: 100px;
+      max-width: 6.3rem;
+      width: 90%;
       text-align: center;
       background-color: #4CAF50;
       color: white;
       padding: 3px 8px;
-      font-size: 30px;
+      font-size: 1.9rem;
       border-radius: 4px;
     }
   }
@@ -34,17 +36,18 @@
     display: flex;
     justify-content: space-around;
     margin: 0 auto;
-    width: 500px;
+    max-width: 31rem;
+    width: 90%;
     flex-wrap: wrap;
-    margin-bottom: 50px;
+    margin-bottom: 3.1rem;
     .spot {
       border: 1px solid black;
       border-radius: 10px;
-      width: 150px;
+      width: 9.4rem;
     }
     .image {
-      width: 100px;
-      height: 100px;
+      width: 6.3rem;
+      height: 6.3rem;
     }
   }
   .edit-icon {
@@ -52,9 +55,10 @@
   }
   .guide-book {
     display: table;
-    width: 550px;
+    max-width: 34.3rem;
+    width: 90%;
     margin: 0 auto;
-    margin-bottom: 150px;
+    margin-bottom: 9.4rem;
     border: 1px solid black;
     border-radius: 10px 10px 0 0;
     overflow: hidden;
@@ -68,19 +72,19 @@
       display: table-row;
     }
     .time-cell {
-      padding: 10px;
+      padding: 0.6rem;
       display: table-cell;
       border-right: 1px solid black;
       text-align: center;
-      width: 150px;
-      font-size: 20px;
+      width: 9.4rem;
+      font-size: 1.25rem;
     }
     .content-cell {
-      padding: 10px;
+      padding: 0.6rem;
       display: table-cell;
       text-align: center;
-      width: 400px;
-      font-size: 20px;
+      width: 25rem;
+      font-size: 1.25rem;
     }
     .spot_link {
       color: blue;
@@ -89,7 +93,7 @@
   .dot-icon {
     width: 100%;
     position: absolute;
-    bottom: 20px;
+    bottom: 1.35rem;
   }
   .select-form {
     position: absolute;
@@ -100,7 +104,7 @@
     display: none;
   }
   .selected-button {
-    font-size: 25px;
+    font-size: 1.6rem;
     color: white;
     background-color:  blue;
     border: 1px solid blue;

--- a/app/assets/stylesheets/trips/show.scss
+++ b/app/assets/stylesheets/trips/show.scss
@@ -8,6 +8,7 @@
     border: 1px solid #ddd;
     border-radius: 8px;
     box-shadow: 0 4px 9px rgba(0, 0, 0, 0.1);
+    padding: 1rem;
     .label-container {
       display: flex;
       text-align: center;
@@ -158,7 +159,8 @@
       justify-content: center;
       margin-bottom: 6.25rem;
       .member-card-style {
-        width: 18.8rem;
+        max-width: 18.8rem;
+        width: 90%;
         border: 1px solid black;
         border-radius: 8px;
         padding: 0.6rem;


### PR DESCRIPTION
### 概要
スマホからプラン作成画面を開いた際にレイアウトが適切に表示されるようにサイズ指定をpxからremに変更しました
また'max-width'と'width: 90%'にすることで画面サイズに合わせて横幅が変更するように修正しました

以下レイアウトになります

<img width="344" alt="スクリーンショット 2025-06-27 19 24 00" src="https://github.com/user-attachments/assets/2d26e788-ff6f-4e3d-9d84-8f8437a3a0f9" />

<img width="322" alt="スクリーンショット 2025-06-27 19 24 19" src="https://github.com/user-attachments/assets/3c5eff06-14a3-4e35-bd60-500b39e513d5" />

<img width="329" alt="スクリーンショット 2025-06-27 19 24 36" src="https://github.com/user-attachments/assets/4f1f3a23-15ef-4a76-a477-2314a738b1d9" />

<img width="319" alt="スクリーンショット 2025-06-27 19 24 44" src="https://github.com/user-attachments/assets/87c35794-879a-4a8e-8e7f-9fa8181a5574" />
