### PR TITLE
ユーザー編集ページのcard-styleの横幅を85%に変更

### DIFF
--- a/app/assets/stylesheets/users/registrations/edit.scss
+++ b/app/assets/stylesheets/users/registrations/edit.scss
@@ -4,7 +4,7 @@
     margin-top: 6.25rem;
     padding: 1.25rem;
     max-width: 25rem;
-    width: 90%;
+    width: 85%;
     border: 1px solid #ddd;
     border-radius: 8px;
     box-shadow: 0 4px 9px rgba(0,0,0,0.1);


### PR DESCRIPTION
### 概要
ユーザー編集ページにおける'card-style'の'width'を85%に変更しました
これによりスマホで開いた時に画面内に'card-style'が収まるように修正されました
