### PR TITLE
tripにおけるrspecテストを修正

### DIFF
--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -1,5 +1,6 @@
 class Trip < ApplicationRecord
   before_create :trip_image
+  after_create :create_trip_user
   DESTINATIONS = [
     "北海道", "青森県", "岩手県", "宮城県", "秋田県", "山形県", "福島県",
     "茨城県", "栃木県", "群馬県", "埼玉県", "千葉県", "東京都", "神奈川県",
@@ -59,7 +60,6 @@ class Trip < ApplicationRecord
   "鹿児島県" => [ 31.56015, 130.55798 ],
   "沖縄県" => [ 26.21240, 127.68093 ]
 }
-  after_create :create_trip_user
 
   has_many :trip_transportations
   has_many :transportations, through: :trip_transportations, dependent: :destroy

--- a/spec/models/trip_spec.rb
+++ b/spec/models/trip_spec.rb
@@ -1,88 +1,109 @@
 require 'rails_helper'
-
 RSpec.describe Trip, type: :model do
-  it "タイトルが入力されていなかったら作成失敗" do
-    trip = Trip.new(
-      title: nil,
-      destination: "北海道",
-      spot_suggestion_limit: "2025-07-10",
-      spot_vote_limit: "2025-07-11",
-      start_time: "08:00",
-      finish_time: "20:00",
-    )
-    expect(trip).not_to be_valid
-    expect(trip.errors[:title]).to include("を入力してください")
-  end
+  let(:user) { User.create!(name: "テスト", email: "test@test", password: 123456) }
 
-  it "目的地が選択されていなかったら作成失敗" do
-    trip = Trip.new(
-      title: "卒業旅行",
-      destination: nil,
-      spot_suggestion_limit: "2025-07-10",
-      spot_vote_limit: "2025-07-11",
-      start_time: "08:00",
-      finish_time: "20:00",
-    )
-    expect(trip).not_to be_valid
-    expect(trip.errors[:destination]).to include("を入力してください")
-  end
-  it "スポット提案期限が入力されていなかったら作成失敗" do
-    trip = Trip.new(
+  let(:trip_data) do
+    {
       title: "卒業旅行",
       destination: "北海道",
-      spot_suggestion_limit: nil,
-      spot_vote_limit: "2025-07-11",
-      start_time: "08:00",
-      finish_time: "20:00",
-    )
-    expect(trip).not_to be_valid
-    expect(trip.errors[:spot_suggestion_limit]).to include("を入力してください")
+      spot_suggestion_limit: Date.today.tomorrow,
+      spot_vote_limit: Date.today.tomorrow + 1,
+      start_time: Time.parse("08:00"),
+      finish_time: Time.parse("20:00"),
+      created_user_id: user.id,
+      decided_plan_id: nil
+    }
   end
-  it "スポット投票期限が入力されていなかったら作成失敗" do
-    trip = Trip.new(
-      title: "卒業旅行",
-      destination: "北海道",
-      spot_suggestion_limit: "2025-07-10",
-      spot_vote_limit: nil,
-      start_time: "08:00",
-      finish_time: "20:00",
-    )
-    expect(trip).not_to be_valid
-    expect(trip.errors[:spot_vote_limit]).to include("を入力してください")
+  describe "バリデーションテスト" do
+    it "タイトルが入力されていなかったら作成失敗" do
+      trip = Trip.new(trip_data.merge(title: nil))
+      expect(trip).not_to be_valid
+      expect(trip.errors[:title]).to include("を入力してください")
+    end
+
+    it "目的地が選択されていなかったら作成失敗" do
+      trip = Trip.new(trip_data.merge(destination: nil))
+      expect(trip).not_to be_valid
+      expect(trip.errors[:destination]).to include("を入力してください")
+    end
+    it "スポット提案期限が入力されていなかったら作成失敗" do
+      trip = Trip.new(trip_data.merge(spot_suggestion_limit: nil))
+      expect(trip).not_to be_valid
+      expect(trip.errors[:spot_suggestion_limit]).to include("を入力してください")
+    end
+    it "スポット投票期限が入力されていなかったら作成失敗" do
+      trip = Trip.new(trip_data.merge(spot_vote_limit: nil))
+      expect(trip).not_to be_valid
+      expect(trip.errors[:spot_vote_limit]).to include("を入力してください")
+    end
+    it "観光開始時間が入力されていなかったら作成失敗" do
+      trip = Trip.new(trip_data.merge(start_time: nil))
+      expect(trip).not_to be_valid
+      expect(trip.errors[:start_time]).to include("を入力してください")
+    end
+    it "観光終了時間が入力されていなかったら作成失敗" do
+      trip = Trip.new(trip_data.merge(finish_time: nil))
+      expect(trip).not_to be_valid
+      expect(trip.errors[:finish_time]).to include("を入力してください")
+    end
+    it "目的地にDESTINATIONS以外の行き先が入力されている場合は作成失敗" do
+      trip = Trip.new(trip_data.merge(destination: "アメリカ"))
+      expect(trip).not_to be_valid
+    end
   end
-  it "観光開始時間が入力されていなかったら作成失敗" do
-    trip = Trip.new(
-      title: "卒業旅行",
-      destination: "北海道",
-      spot_suggestion_limit: "2025-07-10",
-      spot_vote_limit: "2025-07-11",
-      start_time: nil,
-      finish_time: "20:00",
-    )
-    expect(trip).not_to be_valid
-    expect(trip.errors[:start_time]).to include("を入力してください")
-  end
-  it "観光終了時間が入力されていなかったら作成失敗" do
-    trip = Trip.new(
-      title: "卒業旅行",
-      destination: "北海道",
-      spot_suggestion_limit: "2025-07-10",
-      spot_vote_limit: "2025-07-11",
-      start_time: "08:00",
-      finish_time: nil,
-    )
-    expect(trip).not_to be_valid
-    expect(trip.errors[:finish_time]).to include("を入力してください")
-  end
-  it "目的地にDESTINATIONS以外の行き先が入力されている場合は作成失敗" do
-    trip = Trip.new(
-      title: "卒業旅行",
-      destination: "アメリカ",
-      spot_suggestion_limit: "2025-07-10",
-      spot_vote_limit: "2025-07-11",
-      start_time: "08:00",
-      finish_time: "22:00",
-    )
-    expect(trip).not_to be_valid
+  describe "インスタンスメソッド" do
+    describe "create_trip_user" do
+      it "現在のユーザーをリーダーとしてTripUserに作成" do
+        trip = Trip.create!(trip_data)
+        trip_user = trip.trip_users.first
+        expect(trip_user.trip_id).to eq(trip.id)
+        expect(trip_user.user_id).to eq(user.id)
+        expect(trip_user.is_leader).to be true
+      end
+    end
+    describe "within_spot_suggestion_limit_date?" do
+      it "スポット提案期限が昨日の場合はfalseを返す" do
+        trip = Trip.new(trip_data.merge(spot_suggestion_limit: Date.yesterday))
+        expect(trip.within_spot_suggestion_limit_date?).to be false
+      end
+      it "スポット提案期限が今日の場合はtrueを返す" do
+        trip = Trip.new(trip_data.merge(spot_suggestion_limit: Date.today))
+        expect(trip.within_spot_suggestion_limit_date?).to be true
+      end
+    end
+    describe "within_spot_vote_limit_date?" do
+      it "スポット投票期限が昨日の場合はfalseを返す" do
+        trip = Trip.new(trip_data.merge(spot_vote_limit: Date.yesterday))
+        expect(trip.within_spot_vote_limit_date?).to be false
+      end
+      it "スポット投票期限が今日の場合はtrueを返す" do
+        trip = Trip.new(trip_data.merge(spot_vote_limit: Date.today))
+        expect(trip.within_spot_vote_limit_date?).to be true
+      end
+    end
+    describe "until_spot_suggestion_limit_date" do
+      it "スポット提案期限までの日数を返す" do
+        trip = Trip.new(trip_data)
+        expect(trip.until_spot_suggestion_limit_date).to eq 1
+      end
+    end
+    describe "until_spot_vote_limit_date" do
+      it "スポット投票期限までの日数を返す" do
+        trip = Trip.new(trip_data)
+        expect(trip.until_spot_vote_limit_date).to eq 2
+      end
+    end
+    describe "trip_max_time_calculation" do
+      it "観光可能時間を返す" do
+        trip = Trip.new(trip_data)
+        expect(trip.trip_max_time_calculation).to eq 720
+      end
+    end
+      describe "trip_users_sort_by_leader" do
+      it "リーダーが先頭に来るように並び順を変更" do
+        trip = Trip.create!(trip_data)
+        expect(trip.trip_users_sort_by_leader.first.is_leader).to be true
+      end
+    end
   end
 end


### PR DESCRIPTION
### 概要
Tripモデルで定義しているインスタンス変数に対するテストコードを追加しました
またletを用いることで共通のtrip_dataを定義しております

---
### 修正内容
1. create_trip_user: Trip作成時にTripUserがリーダーとして作成されることを確認

2. within_spot_suggestion_limit_date?: 提案期限が過去/当日の場合の挙動確認

3. within_spot_vote_limit_date?: 投票期限が過去/当日の場合の挙動確認

4. until_spot_suggestion_limit_date: 提案期限までの日数が正しく計算されるか確認

5. until_spot_vote_limit_date: 投票期限までの日数が正しく計算されるか確認

6. trip_max_time_calculation: 開始-終了時間の差が分単位で返されるか確認

7. trip_users_sort_by_leader: リーダーが先頭に並ぶか確認

