### PR TITLE
Genreモデルにおけるrspecテストを追加

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,25 @@
+{
+ // IntelliSense を使用して利用可能な属性を学べます。
+ // 既存の属性の説明をホバーして表示します。
+ // 詳細情報は次を確認してください: https://go.microsoft.com/fwlink/?linkid=830387
+ "version": "0.2.0",
+ "configurations": [
+  {
+   "type": "ruby_lsp",
+   "name": "Debug script",
+   "request": "launch",
+   "program": "ruby ${file}"
+  },
+  {
+   "type": "ruby_lsp",
+   "name": "Debug test",
+   "request": "launch",
+   "program": "ruby -Itest ${relativeFile}"
+  },
+  {
+   "type": "ruby_lsp",
+   "name": "Attach debugger",
+   "request": "attach"
+  }
+ ]
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,4 +20,8 @@ class ApplicationController < ActionController::Base
   def after_sign_in_path_for(resource)
     stored_location_for(resource) || homes_path
   end
+
+  def after_sign_up_path_for(resource)
+    stored_location_for(resource) || homes_path
+  end
 end

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -3,7 +3,7 @@ class Genre < ApplicationRecord
   has_many :spots, through: :genre_spots
   belongs_to :category
 
-  validates :name, uniqueness: true
+  validates :name, presence: true, uniqueness: true
 
   def self.genre_category_hash(spot_types)
     genre_names = spot_types.map { |spot_type| spot_type[:name] }.uniq

--- a/db/migrate/20250705043048_change_genre_validation.rb
+++ b/db/migrate/20250705043048_change_genre_validation.rb
@@ -1,0 +1,5 @@
+class ChangeGenreValidation < ActiveRecord::Migration[8.0]
+  def change
+    change_column :genres, :name, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_12_080343) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_05_043048) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -48,7 +48,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_12_080343) do
   end
 
   create_table "genres", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "name"
+    t.string "name", null: false
     t.bigint "category_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/models/genre_spec.rb
+++ b/spec/models/genre_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Genre, type: :model do
     ]
   end
   describe "バリデーションテスト" do
-    it "レコードを作成する際に名前が存在しなかったら作成失敗" do
+    it "名前がnilだったら無効" do
       genre = Genre.new(
         name: nil,
         category_id: category1.id
@@ -22,7 +22,7 @@ RSpec.describe Genre, type: :model do
       expect(genre).not_to be_valid
       expect(genre.errors[:name]).to include("を入力してください")
     end
-    it "レコードを作成する際にすでに名前が存在していたら作成失敗" do
+    it "名前が重複していたら無効" do
       genre = Genre.new(
         name: "museum",
         category_id: category1.id
@@ -30,7 +30,7 @@ RSpec.describe Genre, type: :model do
       expect(genre).not_to be_valid
       expect(genre.errors[:name]).to include("はすでに存在します")
     end
-    it "レコードを作成する際に重複しない名前が存在していたら作成成功" do
+    it "名前が重複していなければ有効" do
       genre = Genre.new(
         name: "park",
         category_id: category1.id

--- a/spec/models/genre_spec.rb
+++ b/spec/models/genre_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe Genre, type: :model do
+  let!(:category1) { Category.create!(name: "sightseeing") }
+  let!(:category2) { Category.create!(name: "leisure_land") }
+
+  let!(:genre1) { Genre.create!(name: "museum", category: category1) }
+  let!(:genre2) { Genre.create!(name: "amusement_park", category: category2) }
+
+  let(:spot_types) do
+    [
+      { name: "museum" },
+      { name: "amusement_park" }
+    ]
+  end
+  describe "バリデーションテスト" do
+    it "レコードを作成する際に名前が存在しなかったら作成失敗" do
+      genre = Genre.new(
+        name: nil,
+        category_id: category1.id
+      )
+      expect(genre).not_to be_valid
+      expect(genre.errors[:name]).to include("を入力してください")
+    end
+    it "レコードを作成する際にすでに名前が存在していたら作成失敗" do
+      genre = Genre.new(
+        name: "museum",
+        category_id: category1.id
+      )
+      expect(genre).not_to be_valid
+      expect(genre.errors[:name]).to include("はすでに存在します")
+    end
+    it "レコードを作成する際に重複しない名前が存在していたら作成成功" do
+      genre = Genre.new(
+        name: "park",
+        category_id: category1.id
+      )
+      expect(genre).to be_valid
+    end
+  end
+  describe "インスタンスメソッド" do
+    describe "self.genre_category_hash(spot_types)" do
+      it "spot_typesに含まれるgenreがそれぞれどのカテゴリーに対応するのかを出力" do
+        expect(Genre.genre_category_hash(spot_types)).to eq({ "amusement_park"=>category2.id, "museum"=>category1.id })
+      end
+    end
+  end
+end


### PR DESCRIPTION
### 概要
Genreモデルにおけるrspecテストを追加しました

---
### 修正内容
以下のテストを作成しました
**バリデーションテスト**
1. 名前がnilだったら無効になること
2. 名前が重複していたら無効になること
3. 名前が重複していなかったら有効になること

**クラスメソッドのテスト**
spot_typesに含まれるgenreがそれぞれどのカテゴリーに対応するのかを出力すること

---