### PR TITLE
Genreモデルのrespecテストにおいて、categoryを作成する際にstay_timeカラムに値を入力するように修正

### DIFF
--- a/spec/models/genre_spec.rb
+++ b/spec/models/genre_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Genre, type: :model do
-  let!(:category1) { Category.create!(name: "sightseeing") }
-  let!(:category2) { Category.create!(name: "leisure_land") }
+  let!(:category1) { Category.create!(name: "sightseeing", stay_time: 90) }
+  let!(:category2) { Category.create!(name: "leisure_land", stay_time: 300) }
 
   let!(:genre1) { Genre.create!(name: "museum", category: category1) }
   let!(:genre2) { Genre.create!(name: "amusement_park", category: category2) }


### PR DESCRIPTION
### 概要
'Category'モデルの'stay_time'カラムに'NOT NULL'制約を設けるため、  
'Genre'モデルのRSpecテストにおいて'Category'レコードを作成する際、'stay_time'カラムに値を入力するよう変更しました。