### PR TITLE
Categoryモデルのrspecテストを追加

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -2,7 +2,8 @@ class Category < ApplicationRecord
   has_many :genres
   has_many :spots
 
-  validates :name, uniqueness: true
+  validates :name, presence: true, uniqueness: true
+  validates :stay_time, presence: true
 
   def self.category_stay_time_in_vote_order(category_ids)
     category_data = Category.where(id: category_ids).index_by(&:id)

--- a/db/migrate/20250705234717_change_category_validation.rb
+++ b/db/migrate/20250705234717_change_category_validation.rb
@@ -1,0 +1,11 @@
+class ChangeCategoryValidation < ActiveRecord::Migration[8.0]
+  def up
+    change_column :categories, :name, :string, null: false
+    change_column :categories, :stay_time, :integer, null: false
+  end
+
+  def down
+    change_column :categories, :name, :string, null: true
+    change_column :categories, :stay_time, :integer, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_05_043048) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_05_234717) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -41,7 +41,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_05_043048) do
 
   create_table "categories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
-    t.integer "stay_time"
+    t.integer "stay_time", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_categories_on_name", unique: true

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe Category, type: :model do
+  let!(:category0) {
+    Category.create!(
+      name: "sightseeing",
+      stay_time: 90
+    )
+  }
+  let!(:category1) {
+    Category.create!(
+      name: "leisure_land",
+      stay_time: 300
+    )
+  }
+  let!(:category2) {
+    Category.create!(
+      name: "nature",
+      stay_time: 45
+    )
+  }
+  let(:category_ids) {
+    [ category1.id, category2.id, category0.id ]
+  }
+  describe "バリデーションテスト" do
+    it "名前がnilだったら無効" do
+      category = Category.new(name: nil, stay_time: 90)
+      expect(category).not_to be_valid
+      expect(category.errors[:name]).to include("を入力してください")
+    end
+    it "名前が重複していたら無効" do
+      category = Category.new(name: "sightseeing", stay_time: 90)
+      expect(category).not_to be_valid
+      expect(category.errors[:name]).to include("はすでに存在します")
+    end
+    it "名前が重複していなければ有効" do
+      category = Category.new(name: "restaurant", stay_time: 60)
+      expect(category).to be_valid
+    end
+    it "滞在時間がnilだったら無効" do
+      category = Category.new(name: "restaurant", stay_time: nil)
+      expect(category).not_to be_valid
+      expect(category.errors[:stay_time]).to include("を入力してください")
+    end
+  end
+  describe "クラスメソッド" do
+    describe "self.category_stay_time_in_vote_order(category_ids)" do
+      it "受け取ったcategory_idsの順番通りにidとstay_timeのハッシュを返す" do
+        expect(Category.category_stay_time_in_vote_order(category_ids)).to eq({
+          category1.id => category1.stay_time,
+          category2.id => category2.stay_time,
+          category0.id => category0.stay_time
+        })
+      end
+    end
+  end
+end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -23,21 +23,21 @@ RSpec.describe Category, type: :model do
     [ category1.id, category2.id, category0.id ]
   }
   describe "バリデーションテスト" do
-    it "名前がnilだったら無効" do
+    it "名前がnilの場合は無効" do
       category = Category.new(name: nil, stay_time: 90)
       expect(category).not_to be_valid
       expect(category.errors[:name]).to include("を入力してください")
     end
-    it "名前が重複していたら無効" do
+    it "名前が重複している場合は無効" do
       category = Category.new(name: "sightseeing", stay_time: 90)
       expect(category).not_to be_valid
       expect(category.errors[:name]).to include("はすでに存在します")
     end
-    it "名前が重複していなければ有効" do
+    it "名前が重複していない場合は有効" do
       category = Category.new(name: "restaurant", stay_time: 60)
       expect(category).to be_valid
     end
-    it "滞在時間がnilだったら無効" do
+    it "滞在時間がnilの場合は無効" do
       category = Category.new(name: "restaurant", stay_time: nil)
       expect(category).not_to be_valid
       expect(category.errors[:stay_time]).to include("を入力してください")


### PR DESCRIPTION
### 概要
Categoryモデルのrspecテストを追加しました

また、categoryモデルに以下のバリデーションを追加しました
- nameカラム : presence: true
- stay_timeカラム : presence: true

---
### 修正内容
以下のテストを実装しました

**バリデーションテスト**

1. 名前がnilの場合は無効

2. 名前が重複している場合は無効

3. 名前が重複していない場合は有効

4. 滞在時間がnilだったら無効

**クラスメソッド**

self.category_stay_time_in_vote_order(category_ids)
- 受け取ったcategory_idsの順番通りにidとstay_timeのハッシュを返す

---