### PR TITLE
DBをmysqlからpostgreslqに変更

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,13 +57,19 @@ jobs:
     runs-on: ubuntu-latest
 
     services:
-      mysql:
-        image: mysql
+      postgres:
+        image: postgres:14
         env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: true
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: tabi_note_test
         ports:
-          - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+          - 5432:5432
+        options: 
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
       # redis:
       #   image: redis
@@ -73,7 +79,7 @@ jobs:
 
     steps:
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y build-essential default-libmysqlclient-dev git pkg-config google-chrome-stable
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y build-essential libpq-dev git pkg-config google-chrome-stable
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -87,7 +93,7 @@ jobs:
       - name: Run tests
         env:
           RAILS_ENV: test
-          DATABASE_URL: mysql2://127.0.0.1:3306
+          DATABASE_URL: postgres://postgres:password@localhost:5432/tabi_note_test
           # REDIS_URL: redis://localhost:6379/0
         run: bin/rails db:test:prepare test test:system
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,6 @@ source "https://rubygems.org"
 gem "rails", "~> 8.0.1"
 # The modern asset pipeline for Rails [https://github.com/rails/propshaft]
 gem "propshaft"
-# Use mysql as the database for Active Record
-gem "mysql2", "~> 0.5"
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", ">= 5.0"
 # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
@@ -71,3 +69,4 @@ gem "pry"
 gem "google_places"
 gem "aws-sdk-s3"
 gem "rspec-rails"
+gem "pg"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,7 +212,6 @@ GEM
     msgpack (1.8.0)
     multi_xml (0.7.2)
       bigdecimal (~> 3.1)
-    mysql2 (0.5.6)
     net-imap (0.5.6)
       date
       net-protocol
@@ -250,6 +249,7 @@ GEM
     parser (3.3.8.0)
       ast (~> 2.4.1)
       racc
+    pg (1.5.9)
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
@@ -465,7 +465,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   kamal
-  mysql2 (~> 0.5)
+  pg
   propshaft
   pry
   pry-byebug

--- a/config/database.yml
+++ b/config/database.yml
@@ -10,10 +10,10 @@
 #   https://dev.mysql.com/doc/refman/5.7/en/password-hashing.html
 #
 default: &default
-  adapter: mysql2
-  encoding: utf8mb4
+  adapter: postgresql
+  encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  username: root
+  username: yuusuke
   password: <%= ENV["DATABASE_PASSWORD"] %>
   host: localhost
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,14 +1,3 @@
-# MySQL. Versions 5.5.8 and up are supported.
-#
-# Install the MySQL driver
-#   gem install mysql2
-#
-# Ensure the MySQL gem is defined in your Gemfile
-#   gem "mysql2"
-#
-# And be sure to use new-style password hashing:
-#   https://dev.mysql.com/doc/refman/5.7/en/password-hashing.html
-#
 default: &default
   adapter: postgresql
   encoding: unicode
@@ -21,9 +10,6 @@ development:
   <<: *default
   database: tabi_note_development
 
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
   <<: *default
   database: tabi_note_test
@@ -31,24 +17,3 @@ test:
 production:
   <<: *default
   database: tabi_note_production
-
-# As with config/credentials.yml, you never want to store sensitive information,
-# like your database password, in your source code. If your source code is
-# ever seen by anyone, they now have access to your database.
-#
-# Instead, provide the password or a full connection URL as an environment
-# variable when you boot the app. For example:
-#
-#   DATABASE_URL="mysql2://myuser:mypass@localhost/somedatabase"
-#
-# If the connection URL is provided in the special DATABASE_URL environment
-# variable, Rails will automatically merge its configuration values on top of
-# the values provided in this file. Alternatively, you can specify a connection
-# URL environment variable explicitly:
-#
-#   production:
-#     url: <%= ENV["MY_APP_DATABASE_URL"] %>
-#
-# Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
-# for a full overview on how database connection configuration can be specified.
-#

--- a/config/database.yml
+++ b/config/database.yml
@@ -28,6 +28,10 @@ test:
   <<: *default
   database: tabi_note_test
 
+production:
+  <<: *default
+  database: tabi_note_production
+
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
 # ever seen by anyone, they now have access to your database.
@@ -48,31 +52,3 @@ test:
 # Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
 # for a full overview on how database connection configuration can be specified.
 #
-
-production:
-  primary:
-    adapter: mysql2
-    encoding: utf8
-    pool: 5
-    url: <%= ENV['JAWSDB_URL'] %>
-  cache:
-    adapter: mysql2
-    encoding: utf8
-    pool: 5
-    url: <%= ENV['JAWSDB_URL'] %>
-    database: tabi_note_production_cache
-    migrations_paths: db/cache_migrate
-  queue:
-    adapter: mysql2
-    encoding: utf8
-    pool: 5
-    url: <%= ENV['JAWSDB_URL'] %>
-    database: tabi_note_production_queue
-    migrations_paths: db/queue_migrate
-  cable:
-    adapter: mysql2
-    encoding: utf8
-    pool: 5
-    url: <%= ENV['JAWSDB_URL'] %>
-    database: tabi_note_production_cable
-    migrations_paths: db/cable_migrate

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,10 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[8.0].define(version: 2025_07_05_234717) do
-  create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_catalog.plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
     t.bigint "record_id", null: false
@@ -21,7 +24,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_05_234717) do
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
-  create_table "active_storage_blobs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "active_storage_blobs", force: :cascade do |t|
     t.string "key", null: false
     t.string "filename", null: false
     t.string "content_type"
@@ -33,13 +36,13 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_05_234717) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table "active_storage_variant_records", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "active_storage_variant_records", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
-  create_table "categories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "categories", force: :cascade do |t|
     t.string "name", null: false
     t.integer "stay_time", null: false
     t.datetime "created_at", null: false
@@ -47,7 +50,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_05_234717) do
     t.index ["name"], name: "index_categories_on_name", unique: true
   end
 
-  create_table "genres", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "genres", force: :cascade do |t|
     t.string "name", null: false
     t.bigint "category_id", null: false
     t.datetime "created_at", null: false
@@ -56,7 +59,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_05_234717) do
     t.index ["name"], name: "index_genres_on_name", unique: true
   end
 
-  create_table "keyword_spots", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "keyword_spots", force: :cascade do |t|
     t.bigint "spot_id", null: false
     t.bigint "keyword_id", null: false
     t.datetime "created_at", null: false
@@ -65,14 +68,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_05_234717) do
     t.index ["spot_id"], name: "index_keyword_spots_on_spot_id"
   end
 
-  create_table "keywords", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "keywords", force: :cascade do |t|
     t.string "word", null: false
     t.string "location_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "plan_spots", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "plan_spots", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "order"
@@ -84,7 +87,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_05_234717) do
     t.index ["spot_id"], name: "index_plan_spots_on_spot_id"
   end
 
-  create_table "plans", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "plans", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "title"
@@ -92,7 +95,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_05_234717) do
     t.index ["trip_id"], name: "index_plans_on_trip_id"
   end
 
-  create_table "spot_suggestions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "spot_suggestions", force: :cascade do |t|
     t.datetime "deadline"
     t.bigint "trip_id", null: false
     t.bigint "spot_id", null: false
@@ -105,7 +108,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_05_234717) do
     t.index ["user_id"], name: "index_spot_suggestions_on_user_id"
   end
 
-  create_table "spot_votes", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "spot_votes", force: :cascade do |t|
     t.datetime "deadline"
     t.bigint "spot_suggestion_id", null: false
     t.bigint "trip_id", null: false
@@ -118,7 +121,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_05_234717) do
     t.index ["user_id"], name: "index_spot_votes_on_user_id"
   end
 
-  create_table "spots", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "spots", force: :cascade do |t|
     t.string "spot_name"
     t.string "unique_number"
     t.string "phone_number"
@@ -134,14 +137,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_05_234717) do
     t.index ["unique_number"], name: "index_spots_on_unique_number", unique: true
   end
 
-  create_table "transportations", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "transportations", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_transportations_on_name", unique: true
   end
 
-  create_table "trip_transportations", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "trip_transportations", force: :cascade do |t|
     t.bigint "trip_id", null: false
     t.bigint "transportation_id", null: false
     t.datetime "created_at", null: false
@@ -150,7 +153,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_05_234717) do
     t.index ["trip_id"], name: "index_trip_transportations_on_trip_id"
   end
 
-  create_table "trip_users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "trip_users", force: :cascade do |t|
     t.boolean "is_leader", default: false, null: false
     t.bigint "user_id", null: false
     t.bigint "trip_id", null: false
@@ -161,7 +164,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_05_234717) do
     t.index ["user_id"], name: "index_trip_users_on_user_id"
   end
 
-  create_table "trips", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "trips", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "title", null: false
@@ -178,7 +181,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_05_234717) do
     t.index ["decided_plan_id"], name: "fk_rails_c84f0818ee"
   end
 
-  create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"


### PR DESCRIPTION
### 概要
全ての環境（開発・テスト・本番）で使用するデータベースを、MySQLからPostgreSQLに変更しました。

これにより、Herokuを用いた本番環境において、従来のMySQLで発生していたクエリ数制限に悩まされることなく、安定したパフォーマンスで利用できるようになりました。