### PR TITLE
Userモデルから2つのインスタンスメソッド trips_in_progressとtrips_pastを削除

### DIFF
--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -1,6 +1,6 @@
 class HomesController < ApplicationController
   def index
-    @trips_in_progress = current_user.trips_in_progress
-    @trips_past = current_user.trips_past
+    @trips_in_progress = current_user.trips.in_progress
+    @trips_past = current_user.trips.completed
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,12 +20,4 @@ class User < ApplicationRecord
     end
     avatar
   end
-
-  def trips_in_progress
-    trips.in_progress
-  end
-
-  def trips_past
-    trips.completed
-  end
 end


### PR DESCRIPTION
### 概要
enumを定義したことにより自動で作成されたスコープを用いた取得方法に切り替えたため、以下のインスタンスメソッドをUserモデルから削除しました
```
  def trips_in_progress
    trips.in_progress
  end

  def trips_past
    trips.completed
  end
```