### PR TITLE
プラン決定済みの処理を早期リターンに変更

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -2,11 +2,11 @@ class PlansController < ApplicationController
   before_action :current_user_leader?, only: [ :edit, :update ]
   def index
     @trip = Trip.find(params[:trip_id])
+    if @trip.decided_plan_id
+      redirect_to trip_path(@trip) and return
+    end
     @plans = @trip.plans
     @trip_users = @trip.trip_users
-    if @trip.decided_plan_id
-      redirect_to trip_path(@trip)
-    end
     @elements = Plan.plans_display_data(plans: @plans, trip: @trip)
   end
   def create


### PR DESCRIPTION
### 概要
'plans#index'において、'@trip.decided_plan_id'が存在する場合に、以降の処理を実行せずに早期リターンするよう変更しました。 

